### PR TITLE
RMS-9: CD to Amplify

### DIFF
--- a/.github/workflows/amplify.yml
+++ b/.github/workflows/amplify.yml
@@ -1,0 +1,44 @@
+# Workflow to push to Amplify on commit
+name: Amplify CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  amplify-deploy:
+    runs-on: ubuntu-latest
+    environment: AmplifyCI
+    
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+    
+      - name: use node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: install and build
+        run: |
+          npm install
+          npm run build
+
+      - name: deploy
+        uses: ambientlight/amplify-cli-action@0.2.2
+        with:
+          amplify_command: push
+          amplify_env: test
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}


### PR DESCRIPTION
- This allows us to automatically deploy to Amplify on commit.
  - This is so that we don't need to do this locally.
  - Unable to test this locally, so there may be a fix commit coming after this.