### PR TITLE
RMS-28: Add Tests

### DIFF
--- a/amplify/backend/ts-code/__tests__/api/AddItem.test.ts
+++ b/amplify/backend/ts-code/__tests__/api/AddItem.test.ts
@@ -1,0 +1,88 @@
+import { AddItem } from "../../src/api/AddItem"
+import { DBSeed, TestConstants } from "../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../__dev__/db/LocalDBClient"
+
+test('will add item correctly when name does not exist', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.EMPTY)
+    const api: AddItem = new AddItem(dbClient)
+
+    await expect(
+        api.execute({ 
+            id: TestConstants.ITEM_ID,
+            name: TestConstants.NAME,
+            description: TestConstants.DESCRIPTION,
+            tags: [TestConstants.TAG], 
+            owner: TestConstants.OWNER,
+            notes: TestConstants.NOTES
+        })
+    ).resolves.toEqual(`Created Item with RMS ID: ${TestConstants.ITEM_ID}`)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME)
+})
+
+test('will add additional item correctly when item already exist', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const api: AddItem = new AddItem(dbClient)
+
+    await expect(
+        api.execute({ 
+            id: TestConstants.ITEM_ID_2,
+            name: TestConstants.NAME,
+            description: TestConstants.DESCRIPTION_2,
+            tags: [TestConstants.TAG, TestConstants.TAG_2], 
+            owner: TestConstants.OWNER_2,
+            notes: TestConstants.NOTES_2
+        })
+    ).resolves.toEqual(`Created Item with RMS ID: ${TestConstants.ITEM_ID_2}`)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME_TWO_ITEMS)
+})
+
+test('will fail to add item when id is not unique', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const api: AddItem = new AddItem(dbClient)
+
+    await expect(
+        api.execute({ 
+            id: TestConstants.ITEM_ID,
+            name: TestConstants.NAME,
+            description: TestConstants.DESCRIPTION_2,
+            tags: [TestConstants.TAG, TestConstants.TAG_2], 
+            owner: TestConstants.OWNER_2,
+            notes: TestConstants.NOTES_2
+        })
+    ).rejects.toThrow(`RMS ID ${TestConstants.ITEM_ID} is not unique.`)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME)
+})
+
+test('will add different name correctly when name already exists', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const api: AddItem = new AddItem(dbClient)
+
+    await expect(
+        api.execute({ 
+            id: TestConstants.ITEM_ID_2,
+            name: TestConstants.NAME_2,
+            description: TestConstants.DESCRIPTION_2,
+            tags: [TestConstants.TAG, TestConstants.TAG_2], 
+            owner: TestConstants.OWNER_2,
+            notes: TestConstants.NOTES_2
+        })
+    ).resolves.toEqual(`Created Item with RMS ID: ${TestConstants.ITEM_ID_2}`)
+    expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES)
+})
+
+test('will fail to add name when id is not unique', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const api: AddItem = new AddItem(dbClient)
+    
+    await expect(
+        api.execute({ 
+            id: TestConstants.ITEM_ID,
+            name: TestConstants.NAME_2,
+            description: TestConstants.DESCRIPTION_2,
+            tags: [TestConstants.TAG, TestConstants.TAG_2], 
+            owner: TestConstants.OWNER_2,
+            notes: TestConstants.NOTES_2
+        })
+    ).rejects.toThrow(`RMS ID ${TestConstants.ITEM_ID} is not unique.`)
+    expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES_FAIL_CREATE)
+})

--- a/amplify/backend/ts-code/__tests__/api/BorrowBatch.test.ts
+++ b/amplify/backend/ts-code/__tests__/api/BorrowBatch.test.ts
@@ -1,0 +1,74 @@
+import { BorrowBatch } from "../../src/api/BorrowBatch"
+import { DBSeed, TestConstants, TestTimestamps } from "../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../__dev__/db/LocalDBClient"
+
+test('will borrow batch correctly when batch exists', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_ONE_BATCH)
+    const api: BorrowBatch = new BorrowBatch(dbClient)
+    
+    // Mock Date
+    Date.now = jest.fn(() => TestTimestamps.BORROW_BATCH)
+
+    await expect(
+        api.execute({ 
+            name: TestConstants.BATCH,
+            borrower: TestConstants.BORROWER,
+            notes: TestConstants.NOTES
+        })
+    ).resolves.toEqual(`Successfully borrowed items in batch '${TestConstants.BATCH}'`)
+    expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES_ONE_BATCH_BORROWED)
+})
+
+// TODO: Race Condition - If one item is partially borrowed, will correctly fail. But then it still might borrow other items in the batch.
+/*
+test('will fail to borrow batch when single item already borrowed', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_ONE_BATCH_PARTIALLY_BORROWED)
+    const api: BorrowBatch = new BorrowBatch(dbClient)
+    
+    // Mock Date
+    Date.now = jest.fn(() => TestTimestamps.BORROW_BATCH)
+
+    await expect(
+        api.execute({ 
+            name: TestConstants.BATCH,
+            borrower: TestConstants.BORROWER,
+            notes: TestConstants.NOTES
+        }).then(() => dbClient.getDB())
+    ).rejects.toThrow(`Unable to borrow item: Item is currently being borrowed by '${TestConstants.BORROWER}'.`)
+    expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES_ONE_BATCH_PARTIALLY_BORROWED)
+})
+*/
+
+test('will fail to borrow batch when batch already borrowed', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_ONE_BATCH_BORROWED)
+    const api: BorrowBatch = new BorrowBatch(dbClient)
+    
+    // Mock Date
+    Date.now = jest.fn(() => TestTimestamps.BORROW_BATCH)
+
+    await expect(
+        api.execute({ 
+            name: TestConstants.BATCH,
+            borrower: TestConstants.BORROWER,
+            notes: TestConstants.NOTES
+        }).then(() => dbClient.getDB())
+    ).rejects.toThrow(`Unable to borrow item: Item is currently being borrowed by '${TestConstants.BORROWER}'.`)
+    expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES_ONE_BATCH_BORROWED)
+})
+
+test('will fail to borrow batch when batch does not exist', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_ONE_BATCH)
+    const api: BorrowBatch = new BorrowBatch(dbClient)
+    
+    // Mock Date
+    Date.now = jest.fn(() => TestTimestamps.BORROW_BATCH)
+
+    await expect(
+        api.execute({ 
+            name: TestConstants.BAD_REQUEST,
+            borrower: TestConstants.BORROWER,
+            notes: TestConstants.NOTES
+        }).then(() => dbClient.getDB())
+    ).rejects.toThrow(`Could not find batch '${TestConstants.BAD_REQUEST}'`)
+    expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES_ONE_BATCH)
+})

--- a/amplify/backend/ts-code/__tests__/api/BorrowItem.test.ts
+++ b/amplify/backend/ts-code/__tests__/api/BorrowItem.test.ts
@@ -1,0 +1,54 @@
+import { BorrowItem } from "../../src/api/BorrowItem"
+import { DBSeed, TestConstants, TestTimestamps } from "../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../__dev__/db/LocalDBClient"
+
+test('will borrow item correctly when id exists', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const api: BorrowItem = new BorrowItem(dbClient)
+    
+    // Mock Date
+    Date.now = jest.fn(() => TestTimestamps.BORROW_ITEM)
+
+    await expect(
+        api.execute({ 
+            ids: [ TestConstants.ITEM_ID ],
+            borrower: TestConstants.BORROWER,
+            notes: TestConstants.NOTES
+        })
+    ).resolves.toEqual(`Successfully borrowed items '${TestConstants.ITEM_ID}'.`)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME_BORROWED)
+})
+
+test('will fail to borrow item when item already borrowed', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME_BORROWED)
+    const api: BorrowItem = new BorrowItem(dbClient)
+    
+    // Mock Date
+    Date.now = jest.fn(() => TestTimestamps.BORROW_ITEM)
+
+    await expect(
+        api.execute({ 
+            ids: [ TestConstants.ITEM_ID ],
+            borrower: TestConstants.BORROWER,
+            notes: TestConstants.NOTES
+        }).then(() => dbClient.getDB())
+    ).rejects.toThrow(`Unable to borrow item: Item is currently being borrowed by '${TestConstants.BORROWER}'.`)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME_BORROWED)
+})
+
+test('will fail to borrow item when id does not exist', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const api: BorrowItem = new BorrowItem(dbClient)
+    
+    // Mock Date
+    Date.now = jest.fn(() => TestTimestamps.BORROW_ITEM)
+
+    await expect(
+        api.execute({ 
+            ids: [ TestConstants.BAD_REQUEST ],
+            borrower: TestConstants.BORROWER,
+            notes: TestConstants.NOTES
+        }).then(() => dbClient.getDB())
+    ).rejects.toThrow(`Couldn't find item ${TestConstants.BAD_REQUEST} in the database.`)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME)
+})

--- a/amplify/backend/ts-code/__tests__/api/CreateBatch.test.ts
+++ b/amplify/backend/ts-code/__tests__/api/CreateBatch.test.ts
@@ -1,0 +1,55 @@
+import { CreateBatch } from "../../src/api/CreateBatch"
+import { DBSeed, TestConstants } from "../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../__dev__/db/LocalDBClient"
+
+test('will create batch correctly when items exist', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES)
+    const api: CreateBatch = new CreateBatch(dbClient)
+
+    await expect(
+        api.execute({ 
+            name: TestConstants.BATCH,
+            ids: [ TestConstants.ITEM_ID, TestConstants.ITEM_ID_2 ]
+        })
+    ).resolves.toEqual(`Successfully created batch '${TestConstants.BATCH}'`)
+    expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES_ONE_BATCH)
+})
+
+test('will override existing batch when batch already exist', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_ONE_BATCH)
+    const api: CreateBatch = new CreateBatch(dbClient)
+
+    await expect(
+        api.execute({ 
+            name: TestConstants.BATCH,
+            ids: [ TestConstants.ITEM_ID ]
+        })
+    ).resolves.toEqual(`Successfully created batch '${TestConstants.BATCH}'`)
+    expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES_ONE_BATCH_MODIFIED)
+})
+
+test('will create batch correctly when a batch already exists', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_ONE_BATCH)
+    const api: CreateBatch = new CreateBatch(dbClient)
+
+    await expect(
+        api.execute({ 
+            name: TestConstants.BATCH_2,
+            ids: [ TestConstants.ITEM_ID ]
+        })
+    ).resolves.toEqual(`Successfully created batch '${TestConstants.BATCH_2}'`)
+    expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES_TWO_BATCH)
+})
+
+test('will fail to create batch when id is invalid', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES)
+    const api: CreateBatch = new CreateBatch(dbClient)
+    
+    await expect(
+        api.execute({ 
+            name: TestConstants.BATCH,
+            ids: [ TestConstants.ITEM_ID, TestConstants.ITEM_ID_2, TestConstants.BAD_REQUEST ]
+        })
+    ).rejects.toThrow(`Unable to find id '${TestConstants.BAD_REQUEST}'`)
+    expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES)
+})

--- a/amplify/backend/ts-code/__tests__/api/DeleteBatch.test.ts
+++ b/amplify/backend/ts-code/__tests__/api/DeleteBatch.test.ts
@@ -1,0 +1,27 @@
+import { DeleteBatch } from "../../src/api/DeleteBatch"
+import { DBSeed, TestConstants } from "../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../__dev__/db/LocalDBClient"
+
+test('will delete batch correctly when batch exist', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_ONE_BATCH)
+    const api: DeleteBatch = new DeleteBatch(dbClient)
+
+    await expect(
+        api.execute({ 
+            name: TestConstants.BATCH
+        })
+    ).resolves.toEqual(`Successfully deleted batch '${TestConstants.BATCH}'`)
+    expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES)
+})
+
+test('will fail to delete batch when batch does not exist', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_ONE_BATCH)
+    const api: DeleteBatch = new DeleteBatch(dbClient)
+
+    await expect(
+        api.execute({ 
+            name: TestConstants.BAD_REQUEST
+        })
+    ).rejects.toThrow(`Batch '${TestConstants.BAD_REQUEST}' not found`)
+    expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES_ONE_BATCH)
+})

--- a/amplify/backend/ts-code/__tests__/api/DeleteItem.test.ts
+++ b/amplify/backend/ts-code/__tests__/api/DeleteItem.test.ts
@@ -1,0 +1,39 @@
+import { DeleteItem } from "../../src/api/DeleteItem"
+import { DBSeed, TestConstants } from "../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../__dev__/db/LocalDBClient"
+
+test('will delete item correctly when name has single item', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES)
+    const api: DeleteItem = new DeleteItem(dbClient)
+
+    await expect(
+        api.execute({ 
+            id: TestConstants.ITEM_ID_2,
+        })
+    ).resolves.toEqual(`Deleted a '${TestConstants.NAME_2}' from the inventory.`)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME)
+})
+
+test('will delete item correctly when name has two items', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME_TWO_ITEMS)
+    const api: DeleteItem = new DeleteItem(dbClient)
+
+    await expect(
+        api.execute({ 
+            id: TestConstants.ITEM_ID_2,
+        })
+    ).resolves.toEqual(`Deleted a '${TestConstants.NAME}' from the inventory.`)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME)
+})
+
+test('will throw exception when id is invalid', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const api: DeleteItem = new DeleteItem(dbClient)
+
+    await expect(
+        api.execute({ 
+            id: TestConstants.BAD_REQUEST,
+        }).then(() => dbClient.getDB())
+    ).rejects.toThrow(`Item ${TestConstants.BAD_REQUEST} doesn't exist.`)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME)
+})

--- a/amplify/backend/ts-code/__tests__/api/GetBatch.test.ts
+++ b/amplify/backend/ts-code/__tests__/api/GetBatch.test.ts
@@ -1,0 +1,27 @@
+import { GetBatch } from "../../src/api/GetBatch"
+import { DBSeed, TestConstants } from "../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../__dev__/db/LocalDBClient"
+
+test('will get batch correctly when batch exist', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_TWO_BATCH)
+    const api: GetBatch = new GetBatch(dbClient)
+
+    await expect(
+        api.execute({ 
+            name: TestConstants.BATCH
+        })
+    ).resolves.toEqual([ TestConstants.ITEM_ID, TestConstants.ITEM_ID_2 ])
+    expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES_TWO_BATCH)
+})
+
+test('will override existing batch when batch already exist', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_TWO_BATCH)
+    const api: GetBatch = new GetBatch(dbClient)
+
+    await expect(
+        api.execute({ 
+            name: TestConstants.BAD_REQUEST
+        })
+    ).rejects.toThrow(`Unable to find Batch '${TestConstants.BAD_REQUEST}'`)
+    expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES_TWO_BATCH)
+})

--- a/amplify/backend/ts-code/__tests__/api/GetItem.test.ts
+++ b/amplify/backend/ts-code/__tests__/api/GetItem.test.ts
@@ -1,0 +1,69 @@
+import { GetItem } from "../../src/api/GetItem"
+import { MainSchema } from "../../src/db/Schemas"
+import { DBSeed, TestConstants } from "../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../__dev__/db/LocalDBClient"
+
+test('will get item correctly when id exists', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME_TWO_ITEMS)
+    const api: GetItem = new GetItem(dbClient)
+    
+    const expected: MainSchema = {
+        name: TestConstants.NAME,
+        description: TestConstants.DESCRIPTION,
+        tags: dbClient.createSet([TestConstants.TAG]),
+        items: { }
+    }
+    expected.items[TestConstants.ITEM_ID] = {
+        owner: TestConstants.OWNER,
+        borrower: "",
+        notes: TestConstants.NOTES,
+    }
+    
+    await expect(
+        api.execute({ 
+            key: TestConstants.ITEM_ID
+        })
+    ).resolves.toEqual(expected)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME_TWO_ITEMS)
+})
+
+test('will get item correctly when name exists', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME_TWO_ITEMS)
+    const api: GetItem = new GetItem(dbClient)
+    
+    const expected: MainSchema = {
+        name: TestConstants.NAME,
+        description: TestConstants.DESCRIPTION,
+        tags: dbClient.createSet([TestConstants.TAG]),
+        items: { }
+    }
+    expected.items[TestConstants.ITEM_ID] = {
+        owner: TestConstants.OWNER,
+        borrower: "",
+        notes: TestConstants.NOTES,
+    }
+    expected.items[TestConstants.ITEM_ID_2] = {
+        owner: TestConstants.OWNER_2,
+        borrower: "",
+        notes: TestConstants.NOTES_2,
+    }
+    
+    await expect(
+        api.execute({ 
+            key: TestConstants.NAME
+        })
+    ).resolves.toEqual(expected)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME_TWO_ITEMS)
+})
+
+test('will throw excpetion when key is invalid', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const api: GetItem = new GetItem(dbClient)
+    
+    await expect(
+        api.execute({ 
+            key: TestConstants.BAD_REQUEST
+        })
+    ).rejects.toThrow(`Couldn't find item '${TestConstants.BAD_REQUEST}'`)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME)
+})

--- a/amplify/backend/ts-code/__tests__/api/ReturnBatch.test.ts
+++ b/amplify/backend/ts-code/__tests__/api/ReturnBatch.test.ts
@@ -1,0 +1,91 @@
+import { ReturnBatch } from "../../src/api/ReturnBatch"
+import { DBSeed, TestConstants, TestTimestamps } from "../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../__dev__/db/LocalDBClient"
+
+test('will return batch correctly when batch borrowed', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_ONE_BATCH_BORROWED)
+    const api: ReturnBatch = new ReturnBatch(dbClient)
+    
+    // Mock Date
+    Date.now = jest.fn(() => TestTimestamps.RETURN_BATCH)
+
+    await expect(
+        api.execute({ 
+            name: TestConstants.BATCH,
+            borrower: TestConstants.BORROWER,
+            notes: TestConstants.NOTES_2
+        })
+    ).resolves.toEqual(`Successfully returned items in batch '${TestConstants.BATCH}'`)
+    expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES_ONE_BATCH_RETURNED)
+})
+
+// TODO: Race Condition - If one item is partially borrowed, will correctly fail. But then it will still return other items in the batch.
+/*
+test('will fail to return batch when batch is only partially borrowed', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_ONE_BATCH_PARTIALLY_BORROWED)
+    const api: ReturnBatch = new ReturnBatch(dbClient)
+    
+    // Mock Date
+    Date.now = jest.fn(() => TestTimestamps.RETURN_BATCH)
+
+    await expect(
+        api.execute({ 
+            name: TestConstants.BATCH,
+            borrower: TestConstants.BORROWER,
+            notes: TestConstants.NOTES_2
+        })
+    ).rejects.toThrow(`Borrower in database is '', which isn't equal to the specified borrower of '${TestConstants.BORROWER}'.`)
+    expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES_ONE_BATCH_PARTIALLY_BORROWED)
+})
+*/
+
+test('will fail to return batch when batch is not borrowed', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_ONE_BATCH)
+    const api: ReturnBatch = new ReturnBatch(dbClient)
+    
+    // Mock Date
+    Date.now = jest.fn(() => TestTimestamps.RETURN_BATCH)
+
+    await expect(
+        api.execute({ 
+            name: TestConstants.BATCH,
+            borrower: TestConstants.BORROWER,
+            notes: TestConstants.NOTES_2
+        })
+    ).rejects.toThrow(`Unable to return item: Borrower in database is '', which isn't equal to the specified borrower of '${TestConstants.BORROWER}'.`)
+    expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES_ONE_BATCH)
+})
+
+test('will fail to return batch when batch is borrowed by somebody else', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_ONE_BATCH_BORROWED)
+    const api: ReturnBatch = new ReturnBatch(dbClient)
+    
+    // Mock Date
+    Date.now = jest.fn(() => TestTimestamps.RETURN_BATCH)
+
+    await expect(
+        api.execute({ 
+            name: TestConstants.BATCH,
+            borrower: TestConstants.BAD_REQUEST,
+            notes: TestConstants.NOTES_2
+        })
+    ).rejects.toThrow(`Unable to return item: Borrower in database is '${TestConstants.BORROWER}', which isn't equal to the specified borrower of '${TestConstants.BAD_REQUEST}'.`)
+    expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES_ONE_BATCH_BORROWED)
+})
+
+test('will fail to return batch when batch does not exist', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_ONE_BATCH_BORROWED)
+    const api: ReturnBatch = new ReturnBatch(dbClient)
+    
+    // Mock Date
+    Date.now = jest.fn(() => TestTimestamps.RETURN_BATCH)
+
+    await expect(
+        api.execute({ 
+            name: TestConstants.BAD_REQUEST,
+            borrower: TestConstants.BORROWER,
+            notes: TestConstants.NOTES_2
+        })
+    ).rejects.toThrow(`Could not find batch '${TestConstants.BAD_REQUEST}'`)
+    expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES_ONE_BATCH_BORROWED)
+})

--- a/amplify/backend/ts-code/__tests__/api/ReturnItem.test.ts
+++ b/amplify/backend/ts-code/__tests__/api/ReturnItem.test.ts
@@ -1,0 +1,71 @@
+import { ReturnItem } from "../../src/api/ReturnItem"
+import { DBSeed, TestConstants, TestTimestamps } from "../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../__dev__/db/LocalDBClient"
+
+test('will return item correctly when id borrowed', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME_BORROWED)
+    const api: ReturnItem = new ReturnItem(dbClient)
+    
+    // Mock Date
+    Date.now = jest.fn(() => TestTimestamps.RETURN_ITEM)
+
+    await expect(
+        api.execute({ 
+            ids: [ TestConstants.ITEM_ID ],
+            borrower: TestConstants.BORROWER,
+            notes: TestConstants.NOTES_2
+        })
+    ).resolves.toEqual(`Successfully returned items '${TestConstants.ITEM_ID}'.`)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME_RETURNED)
+})
+
+test('will fail to return item when item is not borrowed', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const api: ReturnItem = new ReturnItem(dbClient)
+    
+    // Mock Date
+    Date.now = jest.fn(() => TestTimestamps.RETURN_ITEM)
+
+    await expect(
+        api.execute({ 
+            ids: [ TestConstants.ITEM_ID ],
+            borrower: TestConstants.BORROWER,
+            notes: TestConstants.NOTES_2
+        })
+    ).rejects.toThrow(`Unable to return item: Borrower in database is '', which isn't equal to the specified borrower of '${TestConstants.BORROWER}'.`)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME)
+})
+
+test('will fail to return item when item is borrowed by somebody else', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME_BORROWED)
+    const api: ReturnItem = new ReturnItem(dbClient)
+    
+    // Mock Date
+    Date.now = jest.fn(() => TestTimestamps.RETURN_ITEM)
+
+    await expect(
+        api.execute({ 
+            ids: [ TestConstants.ITEM_ID ],
+            borrower: TestConstants.BAD_REQUEST,
+            notes: TestConstants.NOTES_2
+        })
+    ).rejects.toThrow(`Unable to return item: Borrower in database is '${TestConstants.BORROWER}', which isn't equal to the specified borrower of '${TestConstants.BAD_REQUEST}'.`)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME_BORROWED)
+})
+
+test('will fail to return item when id does not exist', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME_BORROWED)
+    const api: ReturnItem = new ReturnItem(dbClient)
+    
+    // Mock Date
+    Date.now = jest.fn(() => TestTimestamps.RETURN_ITEM)
+
+    await expect(
+        api.execute({ 
+            ids: [ TestConstants.BAD_REQUEST ],
+            borrower: TestConstants.BORROWER,
+            notes: TestConstants.NOTES_2
+        })
+    ).rejects.toThrow(`Couldn't find item ${TestConstants.BAD_REQUEST} in the database.`)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME_BORROWED)
+})

--- a/amplify/backend/ts-code/__tests__/api/SearchItem.test.ts
+++ b/amplify/backend/ts-code/__tests__/api/SearchItem.test.ts
@@ -1,0 +1,33 @@
+import { SearchItem, SearchItemReturn } from "../../src/api/SearchItem"
+import { DBSeed, TestConstants } from "../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../__dev__/db/LocalDBClient"
+
+test('will search item correctly when tag exists', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES)
+    const api: SearchItem = new SearchItem(dbClient)
+    
+    await api.execute({ 
+        tags: [ TestConstants.TAG_2, TestConstants.TAG ]
+    }).then((search: SearchItemReturn) => {
+        expect(Object.keys(search.map).length).toEqual(2)
+        expect(search.map[TestConstants.NAME].occurrences).toEqual(1)
+        expect(search.map[TestConstants.NAME].relevance).toEqual(1)
+        expect(search.map[TestConstants.NAME_2].occurrences).toEqual(2)
+        expect(search.map[TestConstants.NAME_2].relevance).toEqual(0)
+        expect(search.entries[0].name).toEqual(TestConstants.NAME_2)
+        expect(search.entries[1].name).toEqual(TestConstants.NAME)
+    })
+    expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES)
+})
+
+test('will return nothing when tag does not exists', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES)
+    const api: SearchItem = new SearchItem(dbClient)
+    
+    await api.execute({ 
+        tags: [ TestConstants.BAD_REQUEST ]
+    }).then((search: SearchItemReturn) => {
+        expect(Object.keys(search.map).length).toEqual(0)
+    })
+    expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES)
+})

--- a/amplify/backend/ts-code/__tests__/api/UpdateDescription.test.ts
+++ b/amplify/backend/ts-code/__tests__/api/UpdateDescription.test.ts
@@ -1,0 +1,29 @@
+import { UpdateDescription } from "../../src/api/UpdateDescription"
+import { DBSeed, TestConstants } from "../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../__dev__/db/LocalDBClient"
+
+test('will update description correctly when name exists', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const api: UpdateDescription = new UpdateDescription(dbClient)
+    
+    await expect(
+        api.execute({ 
+            name: TestConstants.NAME,
+            description: TestConstants.DESCRIPTION_2
+        })
+    ).resolves.toEqual(`Successfully updated description of '${TestConstants.NAME}'`)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME_CHANGE_DESCRIPTION)
+})
+
+test('will throw excpetion when name is invalid', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const api: UpdateDescription = new UpdateDescription(dbClient)
+    
+    await expect(
+        api.execute({ 
+            name: TestConstants.BAD_REQUEST,
+            description: TestConstants.DESCRIPTION_2
+        })
+    ).rejects.toThrow("Cannot set property 'description' of undefined")
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME)
+})

--- a/amplify/backend/ts-code/__tests__/api/UpdateItemNotes.test.ts
+++ b/amplify/backend/ts-code/__tests__/api/UpdateItemNotes.test.ts
@@ -1,0 +1,29 @@
+import { UpdateItemNotes } from "../../src/api/UpdateItemNotes"
+import { DBSeed, TestConstants } from "../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../__dev__/db/LocalDBClient"
+
+test('will update note correctly when id exists', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const api: UpdateItemNotes = new UpdateItemNotes(dbClient)
+    
+    await expect(
+        api.execute({ 
+            id: TestConstants.ITEM_ID,
+            note: TestConstants.NOTES_2
+        })
+    ).resolves.toEqual(`Successfully updated notes about item '${TestConstants.ITEM_ID}'`)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME_CHANGE_NOTE)
+})
+
+test('will throw excpetion when id is invalid', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const api: UpdateItemNotes = new UpdateItemNotes(dbClient)
+    
+    await expect(
+        api.execute({ 
+            id: TestConstants.BAD_REQUEST,
+            note: TestConstants.NOTES_2
+        }).then(() => dbClient.getDB())
+    ).rejects.toThrow(`Couldn't find item ${TestConstants.BAD_REQUEST} in the database.`)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME)
+})

--- a/amplify/backend/ts-code/__tests__/api/UpdateItemOwner.test.ts
+++ b/amplify/backend/ts-code/__tests__/api/UpdateItemOwner.test.ts
@@ -1,0 +1,45 @@
+import { UpdateItemOwner } from "../../src/api/UpdateItemOwner"
+import { DBSeed, TestConstants } from "../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../__dev__/db/LocalDBClient"
+
+test('will update description correctly when id exists', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const api: UpdateItemOwner = new UpdateItemOwner(dbClient)
+    
+    await expect(
+        api.execute({ 
+            id: TestConstants.ITEM_ID,
+            currentOwner: TestConstants.OWNER,
+            newOwner: TestConstants.OWNER_2
+        })
+    ).resolves.toEqual(`Successfully updated owner for item '${TestConstants.ITEM_ID}'`)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME_CHANGE_OWNER)
+})
+
+test('will throw excpetion when owner is invalid', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const api: UpdateItemOwner = new UpdateItemOwner(dbClient)
+    
+    await expect(
+        api.execute({ 
+            id: TestConstants.ITEM_ID,
+            currentOwner: TestConstants.BAD_REQUEST,
+            newOwner: TestConstants.OWNER_2
+        }).then(() => dbClient.getDB())
+    ).rejects.toThrow(`'owner' is currently '${TestConstants.OWNER}', which isn't equal to the expected value of '${TestConstants.BAD_REQUEST}'.`)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME)
+})
+
+test('will throw excpetion when id is invalid', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const api: UpdateItemOwner = new UpdateItemOwner(dbClient)
+    
+    await expect(
+        api.execute({ 
+            id: TestConstants.BAD_REQUEST,
+            currentOwner: TestConstants.OWNER,
+            newOwner: TestConstants.OWNER_2
+        }).then(() => dbClient.getDB())
+    ).rejects.toThrow(`Couldn't find item ${TestConstants.BAD_REQUEST} in the database.`)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME)
+})

--- a/amplify/backend/ts-code/__tests__/api/UpdateTags.test.ts
+++ b/amplify/backend/ts-code/__tests__/api/UpdateTags.test.ts
@@ -1,0 +1,30 @@
+import { UpdateDescription } from "../../src/api/UpdateDescription"
+import { UpdateTags } from "../../src/api/UpdateTags"
+import { DBSeed, TestConstants} from "../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../__dev__/db/LocalDBClient"
+
+test('will update tags correctly when name exists', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const api: UpdateTags = new UpdateTags(dbClient)
+    
+    await expect(
+        api.execute({ 
+            name: TestConstants.NAME,
+            tags: [ TestConstants.TAG_2 ]
+        })
+    ).resolves.toEqual(`Successfully updated tags for '${TestConstants.NAME}'`)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME_CHANGE_TAGS)
+})
+
+test('will throw excpetion when name is invalid', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const api: UpdateTags = new UpdateTags(dbClient)
+    
+    await expect(
+        api.execute({ 
+            name: TestConstants.BAD_REQUEST,
+            tags: [ TestConstants.TAG_2 ]
+        }).then(() => dbClient.getDB())
+    ).rejects.toThrow(`Could not find '${TestConstants.BAD_REQUEST}' in the database.`)
+    expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME)
+})

--- a/amplify/backend/ts-code/__tests__/api/internal/PrintTable.test.ts
+++ b/amplify/backend/ts-code/__tests__/api/internal/PrintTable.test.ts
@@ -1,0 +1,34 @@
+import { PrintTable } from "../../../src/api/internal/PrintTable"
+import { MAIN_TABLE } from "../../../src/db/Schemas"
+import { DBSeed, TestConstants } from "../../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../../__dev__/db/LocalDBClient"
+
+test('will print item correctly when main table is empty', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.EMPTY)
+    const api: PrintTable = new PrintTable(dbClient)
+    
+    await expect(
+        api.execute({ 
+            tableName: MAIN_TABLE
+        })
+    ).resolves.toEqual({
+        "$response": null,
+        Items: [],
+        Count: 0,
+        ScannedCount: 0
+    })
+    expect(dbClient.getDB()).toEqual(DBSeed.EMPTY)
+})
+
+test('will fail to print item when table name is invalid', () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.EMPTY)
+    const api: PrintTable = new PrintTable(dbClient)
+    
+    // Throws exceiption outside of a promise
+    expect(() => 
+        api.execute({ 
+            tableName: TestConstants.BAD_REQUEST
+        })
+    ).toThrow("Unsupported Table Name: " + TestConstants.BAD_REQUEST)
+    expect(dbClient.getDB()).toEqual(DBSeed.EMPTY)
+})

--- a/amplify/backend/ts-code/__tests__/handlers/router/Router.test.ts
+++ b/amplify/backend/ts-code/__tests__/handlers/router/Router.test.ts
@@ -1,0 +1,477 @@
+import { AddItem } from "../../../src/api/AddItem"
+import { BorrowBatch } from "../../../src/api/BorrowBatch"
+import { BorrowItem } from "../../../src/api/BorrowItem"
+import { CreateBatch } from "../../../src/api/CreateBatch"
+import { DeleteBatch } from "../../../src/api/DeleteBatch"
+import { DeleteItem } from "../../../src/api/DeleteItem"
+import { GetBatch, getBatchItem } from "../../../src/api/GetBatch"
+import { GetItem, getItemHeader, getItemItem } from "../../../src/api/GetItem"
+import { PrintTable } from "../../../src/api/internal/PrintTable"
+import { ReturnBatch } from "../../../src/api/ReturnBatch"
+import { ReturnItem } from "../../../src/api/ReturnItem"
+import { SearchItem, searchItemItem } from "../../../src/api/SearchItem"
+import { UpdateDescription } from "../../../src/api/UpdateDescription"
+import { UpdateItemNotes } from "../../../src/api/UpdateItemNotes"
+import { UpdateItemOwner } from "../../../src/api/UpdateItemOwner"
+import { UpdateTags } from "../../../src/api/UpdateTags"
+import { MainSchema } from "../../../src/db/Schemas"
+import { ADVANCED_HELP_MENU, BASIC_HELP_MENU, HELP_MENU, Router } from "../../../src/handlers/router/Router"
+import { DBSeed, TestConstants, TestTimestamps } from "../../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../../__dev__/db/LocalDBClient"
+
+test('will return help menu correctly when calling help', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.EMPTY)
+    const router: Router = new Router(dbClient)
+
+    await router.processRequest("help", TestConstants.NUMBER)
+        .then((output: string) => {
+            expect(output).toEqual(HELP_MENU)
+        })
+})
+
+test('will return basic help menu correctly when calling help basic', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.EMPTY)
+    const router: Router = new Router(dbClient)
+
+    await router.processRequest("help basic", TestConstants.NUMBER)
+        .then((output: string) => {
+            expect(output).toEqual(BASIC_HELP_MENU)
+        })
+})
+
+test('will return advanced help menu correctly when calling help advanced', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.EMPTY)
+    const router: Router = new Router(dbClient)
+
+    await router.processRequest("help advanced", TestConstants.NUMBER)
+        .then((output: string) => {
+            expect(output).toEqual(ADVANCED_HELP_MENU)
+        })
+})
+
+test('will complain when invalid service call is passed', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.EMPTY)
+    const router: Router = new Router(dbClient)
+
+    await router.processRequest(TestConstants.BAD_REQUEST, TestConstants.NUMBER)
+        .then((output: string) => {
+            expect(output).toEqual("Invalid Request. Please reply with 'help' to get valid operations.")
+        })
+})
+
+test('will complain when there is no transaction to abort', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.EMPTY)
+    const router: Router = new Router(dbClient)
+
+    await router.processRequest("abort", TestConstants.NUMBER)
+        .then((output: string) => {
+            expect(output).toEqual("No Request to Abort.")
+        })
+})
+
+test('will abort correctly when typing in command in the middle of a service dialogue', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES)
+    const router: Router = new Router(dbClient)
+
+    await router.processRequest(DeleteItem.NAME, TestConstants.NUMBER)
+        .then((output: string) => {
+            expect(output).toEqual("ID of item:")
+            return router.processRequest(TestConstants.ITEM_ID_2, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual(`Type 'y' to confirm that you want to delete item: '${TestConstants.ITEM_ID_2}'`)
+            return router.processRequest("abort", TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("Request Reset")
+            expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES)
+        })
+})
+
+test('will internal print table correctly when using router', async () => {
+    const tableNames: string[] = ["main", "batch", "history", "items", "tags"]
+
+    await tableNames.forEach(async (name: string) => {
+        const dbClient: LocalDBClient = new LocalDBClient(DBSeed.EMPTY)
+        const router: Router = new Router(dbClient)
+
+        await router.processRequest(PrintTable.NAME, TestConstants.NUMBER)
+            .then((output: string) => {
+                expect(output).toEqual("Name of table: (Options: main, batch, history, items, tags, transactions)")
+                return router.processRequest(name, TestConstants.NUMBER)
+            }).then((output: string) => {
+                expect(output).toEqual("[]\nEND")
+            })
+    })
+})
+
+test('will internal print table correctly when using router and invalid table name', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.EMPTY)
+    const router: Router = new Router(dbClient)
+
+    await expect(() => 
+        router.processRequest(PrintTable.NAME, TestConstants.NUMBER)
+            .then((output: string) => {
+                expect(output).toEqual("Name of table: (Options: main, batch, history, items, tags, transactions)")
+                return router.processRequest(TestConstants.BAD_REQUEST, TestConstants.NUMBER)
+            })
+    ).rejects.toThrow("Unsupported Table Name: " + TestConstants.BAD_REQUEST)
+})
+
+test('will add item correctly when name does not exist', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.EMPTY)
+    const router: Router = new Router(dbClient)
+
+    await router.processRequest(AddItem.NAME, TestConstants.NUMBER)
+        .then((output: string) => {
+            expect(output).toEqual("Name of item:")
+            return router.processRequest(TestConstants.NAME, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("Related Category Tags (separated by spaces):")
+            return router.processRequest(TestConstants.TAG, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("Optional description of this item:")
+            return router.processRequest(TestConstants.DESCRIPTION, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("Intended Unique RMS ID number:")
+            return router.processRequest(TestConstants.ITEM_ID, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("Owner of this item (or location where it's stored if church owned):")
+            return router.processRequest(TestConstants.OWNER, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("Optional notes about this specific item:")
+            return router.processRequest(TestConstants.NOTES, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual(`Created Item with RMS ID: ${TestConstants.ITEM_ID}`)
+            expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME)
+        })
+})
+
+test('will add item correctly when name exists', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const router: Router = new Router(dbClient)
+
+    await router.processRequest(AddItem.NAME, TestConstants.NUMBER)
+        .then((output: string) => {
+            expect(output).toEqual("Name of item:")
+            return router.processRequest(TestConstants.NAME, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("Intended Unique RMS ID number:")
+            return router.processRequest(TestConstants.ITEM_ID_2, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("Owner of this item (or location where it's stored if church owned):")
+            return router.processRequest(TestConstants.OWNER_2, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("Optional notes about this specific item:")
+            return router.processRequest(TestConstants.NOTES_2, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual(`Created Item with RMS ID: ${TestConstants.ITEM_ID_2}`)
+            expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME_TWO_ITEMS)
+        })
+})
+
+test('will get item correctly when given valid is', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const router: Router = new Router(dbClient)
+
+    const expectedItem: MainSchema = {
+        name: TestConstants.NAME,
+        description: TestConstants.DESCRIPTION,
+        tags: dbClient.createSet([TestConstants.TAG]),
+        items: { }
+    }
+    expectedItem.items[TestConstants.ITEM_ID] = {
+        owner: TestConstants.OWNER,
+        borrower: "",
+        notes: TestConstants.NOTES,
+    }
+    const expectedStr: string = getItemHeader(expectedItem) + getItemItem(expectedItem, TestConstants.ITEM_ID)
+
+    await router.processRequest(GetItem.NAME, TestConstants.NUMBER)
+        .then((output: string) => {
+            expect(output).toEqual("Name or ID of item:")
+            return router.processRequest(TestConstants.ITEM_ID, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual(expectedStr)
+        })
+})
+
+test('will update description correctly when using router', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const router: Router = new Router(dbClient)
+
+    await router.processRequest(UpdateDescription.NAME, TestConstants.NUMBER)
+        .then((output: string) => {
+            expect(output).toEqual("Name of item:")
+            return router.processRequest(TestConstants.NAME, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("New Description:")
+            return router.processRequest(TestConstants.DESCRIPTION_2, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual(`Successfully updated description of '${TestConstants.NAME}'`)
+            expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME_CHANGE_DESCRIPTION)
+        })
+})
+
+test('will update item notes correctly when using router', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const router: Router = new Router(dbClient)
+
+    await router.processRequest(UpdateItemNotes.NAME, TestConstants.NUMBER)
+        .then((output: string) => {
+            expect(output).toEqual("ID of item:")
+            return router.processRequest(TestConstants.ITEM_ID, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("New Note:")
+            return router.processRequest(TestConstants.NOTES_2, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual(`Successfully updated notes about item '${TestConstants.ITEM_ID}'`)
+            expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME_CHANGE_NOTE)
+        })
+})
+
+test('will update item owner correctly when using router', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const router: Router = new Router(dbClient)
+
+    await router.processRequest(UpdateItemOwner.NAME, TestConstants.NUMBER)
+        .then((output: string) => {
+            expect(output).toEqual("ID of item:")
+            return router.processRequest(TestConstants.ITEM_ID, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("Current Owner (or location where it's stored if church owned):")
+            return router.processRequest(TestConstants.OWNER, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("New Owner (or location where it's stored if church owned):")
+            return router.processRequest(TestConstants.OWNER_2, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual(`Successfully updated owner for item '${TestConstants.ITEM_ID}'`)
+            expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME_CHANGE_OWNER)
+        })
+})
+
+test('will update tags correctly when using router', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const router: Router = new Router(dbClient)
+
+    await router.processRequest(UpdateTags.NAME, TestConstants.NUMBER)
+        .then((output: string) => {
+            expect(output).toEqual("Name of item:")
+            return router.processRequest(TestConstants.NAME, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("New Tags (separated by spaces):")
+            return router.processRequest(TestConstants.TAG_2, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual(`Successfully updated tags for '${TestConstants.NAME}'`)
+            expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME_CHANGE_TAGS)
+        })
+})
+
+test('will search item correctly when using router', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const router: Router = new Router(dbClient)
+
+    await router.processRequest(SearchItem.NAME, TestConstants.NUMBER)
+        .then((output: string) => {
+            expect(output).toEqual("Tags to search for (separated by spaces):")
+            return router.processRequest(TestConstants.TAG, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual(
+                "1 items found."
+                + searchItemItem(TestConstants.NAME, 1, [ TestConstants.ITEM_ID ], [])
+            )
+        })
+})
+
+test('will search borrowed item correctly when using router', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME_BORROWED)
+    const router: Router = new Router(dbClient)
+
+    await router.processRequest(SearchItem.NAME, TestConstants.NUMBER)
+        .then((output: string) => {
+            expect(output).toEqual("Tags to search for (separated by spaces):")
+            return router.processRequest(TestConstants.TAG, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual(
+                "1 items found."
+                + searchItemItem(TestConstants.NAME, 1, [], [ TestConstants.ITEM_ID ])
+            )
+        })
+})
+
+test('will search item correctly when using router and bad tag', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const router: Router = new Router(dbClient)
+
+    await router.processRequest(SearchItem.NAME, TestConstants.NUMBER)
+        .then((output: string) => {
+            expect(output).toEqual("Tags to search for (separated by spaces):")
+            return router.processRequest(TestConstants.BAD_REQUEST, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("No items found.")
+        })
+})
+
+test('will borrow item correctly when using router', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const router: Router = new Router(dbClient)
+
+    // Mock Date
+    Date.now = jest.fn(() => TestTimestamps.BORROW_ITEM)
+
+    await router.processRequest(BorrowItem.NAME, TestConstants.NUMBER)
+        .then((output: string) => {
+            expect(output).toEqual("IDs of Items (separated by spaces):")
+            return router.processRequest(TestConstants.ITEM_ID, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("Name of intended borrower:")
+            return router.processRequest(TestConstants.BORROWER, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("Optional notes to leave about this action:")
+            return router.processRequest(TestConstants.NOTES, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual(`Successfully borrowed items '${TestConstants.ITEM_ID}'.`)
+            expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME_BORROWED)
+        })
+})
+
+test('will return item correctly when using router', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME_BORROWED)
+    const router: Router = new Router(dbClient)
+
+    // Mock Date
+    Date.now = jest.fn(() => TestTimestamps.RETURN_ITEM)
+
+    await router.processRequest(ReturnItem.NAME, TestConstants.NUMBER)
+        .then((output: string) => {
+            expect(output).toEqual("IDs of Items (separated by spaces):")
+            return router.processRequest(TestConstants.ITEM_ID, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("Name of current borrower:")
+            return router.processRequest(TestConstants.BORROWER, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("Optional notes to leave about this action:")
+            return router.processRequest(TestConstants.NOTES_2, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual(`Successfully returned items '${TestConstants.ITEM_ID}'.`)
+            expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME_RETURNED)
+        })
+})
+
+test('will create batch correctly when using router', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES)
+    const router: Router = new Router(dbClient)
+
+    await router.processRequest(CreateBatch.NAME, TestConstants.NUMBER)
+        .then((output: string) => {
+            expect(output).toEqual("Name of Batch:")
+            return router.processRequest(TestConstants.BATCH, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("List of IDs (separated by spaces):")
+            return router.processRequest(TestConstants.ITEM_ID + " " + TestConstants.ITEM_ID_2, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual(`Successfully created batch '${TestConstants.BATCH}'`)
+            expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES_ONE_BATCH)
+        })
+})
+
+test('will get batch correctly when using router', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_ONE_BATCH)
+    const router: Router = new Router(dbClient)
+
+    await router.processRequest(GetBatch.NAME, TestConstants.NUMBER)
+        .then((output: string) => {
+            expect(output).toEqual("Name of Batch:")
+            return router.processRequest(TestConstants.BATCH, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual(
+                `batch: ${TestConstants.BATCH}`
+                + getBatchItem(TestConstants.ITEM_ID, TestConstants.NAME, TestConstants.OWNER, "")
+                + getBatchItem(TestConstants.ITEM_ID_2, TestConstants.NAME_2, TestConstants.OWNER_2, "")
+            )
+        })
+})
+
+test('will borrow batch correctly when using router', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_ONE_BATCH)
+    const router: Router = new Router(dbClient)
+
+    // Mock Date
+    Date.now = jest.fn(() => TestTimestamps.BORROW_BATCH)
+
+    await router.processRequest(BorrowBatch.NAME, TestConstants.NUMBER)
+        .then((output: string) => {
+            expect(output).toEqual("Name of Batch:")
+            return router.processRequest(TestConstants.BATCH, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("Name of intended borrower:")
+            return router.processRequest(TestConstants.BORROWER, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("Optional notes to leave about this action:")
+            return router.processRequest(TestConstants.NOTES, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual(`Successfully borrowed items in batch '${TestConstants.BATCH}'`)
+            expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES_ONE_BATCH_BORROWED)
+        })
+})
+
+test('will return batch correctly when using router', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_ONE_BATCH_BORROWED)
+    const router: Router = new Router(dbClient)
+
+    // Mock Date
+    Date.now = jest.fn(() => TestTimestamps.RETURN_BATCH)
+
+    await router.processRequest(ReturnBatch.NAME, TestConstants.NUMBER)
+    .then((output: string) => {
+        expect(output).toEqual("Name of Batch:")
+        return router.processRequest(TestConstants.BATCH, TestConstants.NUMBER)
+    }).then((output: string) => {
+        expect(output).toEqual("Name of current borrower:")
+        return router.processRequest(TestConstants.BORROWER, TestConstants.NUMBER)
+    }).then((output: string) => {
+        expect(output).toEqual("Optional notes to leave about this action:")
+        return router.processRequest(TestConstants.NOTES_2, TestConstants.NUMBER)
+    }).then((output: string) => {
+        expect(output).toEqual(`Successfully returned items in batch '${TestConstants.BATCH}'`)
+        expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES_ONE_BATCH_RETURNED)
+    })
+})
+
+test('will delete batch correctly when using router', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_TWO_BATCH)
+    const router: Router = new Router(dbClient)
+
+    await router.processRequest(DeleteBatch.NAME, TestConstants.NUMBER)
+        .then((output: string) => {
+            expect(output).toEqual("Name of Batch:")
+            return router.processRequest(TestConstants.BATCH_2, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual(`Type 'y' to confirm that you want to delete batch: '${TestConstants.BATCH_2}'`)
+            return router.processRequest("not y", TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("ERROR: Didn't receive 'y'. Please reply again with a 'y' to proceed with deleting the object, or 'abort' to abort the transaction.")
+            return router.processRequest("y", TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual(`Successfully deleted batch '${TestConstants.BATCH_2}'`)
+            expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES_ONE_BATCH)
+        })
+})
+
+test('will delete item correctly when using router', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES)
+    const router: Router = new Router(dbClient)
+
+    await router.processRequest(DeleteItem.NAME, TestConstants.NUMBER)
+        .then((output: string) => {
+            expect(output).toEqual("ID of item:")
+            return router.processRequest(TestConstants.ITEM_ID_2, TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual(`Type 'y' to confirm that you want to delete item: '${TestConstants.ITEM_ID_2}'`)
+            return router.processRequest("not y", TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual("ERROR: Didn't receive 'y'. Please reply again with a 'y' to proceed with deleting the object, or 'abort' to abort the transaction.")
+            return router.processRequest("y", TestConstants.NUMBER)
+        }).then((output: string) => {
+            expect(output).toEqual(`Deleted a '${TestConstants.NAME_2}' from the inventory.`)
+            expect(dbClient.getDB()).toEqual(DBSeed.ONE_NAME)
+        })
+})


### PR DESCRIPTION
## Description

- Created Tests for all API functions, as well as their router commands.

## Tests
```
-----------------------|---------|----------|---------|---------|-------------------
File                   | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------|---------|----------|---------|---------|-------------------
All files              |   86.76 |    88.33 |   85.22 |   86.71 |                   
 api                   |     100 |    98.21 |     100 |     100 |                   
  AddItem.js           |     100 |      100 |     100 |     100 |                   
  BorrowBatch.js       |     100 |      100 |     100 |     100 |                   
  BorrowItem.js        |     100 |      100 |     100 |     100 |                   
  CreateBatch.js       |     100 |      100 |     100 |     100 |                   
  DeleteBatch.js       |     100 |      100 |     100 |     100 |                   
  DeleteItem.js        |     100 |      100 |     100 |     100 |                   
  GetBatch.js          |     100 |      100 |     100 |     100 |                   
  GetItem.js           |     100 |       80 |     100 |     100 | 70-78             
  ReturnBatch.js       |     100 |      100 |     100 |     100 |                   
  ReturnItem.js        |     100 |      100 |     100 |     100 |                   
  SearchItem.js        |     100 |      100 |     100 |     100 |                   
  UpdateDescription.js |     100 |      100 |     100 |     100 |                   
  UpdateItemNotes.js   |     100 |      100 |     100 |     100 |                   
  UpdateItemOwner.js   |     100 |      100 |     100 |     100 |                   
  UpdateTags.js        |     100 |      100 |     100 |     100 |                   
 api/internal          |   81.25 |       75 |   76.47 |   82.61 |                   
  PrintTable.js        |   81.25 |       75 |   76.47 |   82.61 | 29-35,40-41,90    
 db                    |   95.72 |    83.33 |   98.61 |   95.53 |                   
  BatchTable.js        |    97.5 |    83.33 |     100 |   97.22 | 125               
  ItemTable.js         |   89.29 |    66.67 |   90.91 |   89.29 | 79-83             
  MainTable.js         |    96.3 |       90 |     100 |    96.3 | 35,38             
  Schemas.js           |     100 |      100 |     100 |     100 |                   
  TagTable.js          |   95.45 |    81.25 |     100 |      95 | 20,125            
  TransactionsTable.js |     100 |      100 |     100 |     100 |                   
 handlers/router       |   75.93 |    95.83 |   47.06 |   76.64 |                   
  Router.js            |   97.62 |    95.83 |   88.89 |   97.62 | 143-144           
  SMSRouter.js         |       0 |      100 |       0 |       0 | 2-58              
 handlers/tsv          |       0 |        0 |       0 |       0 |                   
  TSV.js               |       0 |        0 |       0 |       0 | 2-105             
 injection/db          |       0 |      100 |       0 |       0 |                   
  DBClient.js          |       0 |      100 |     100 |       0 | 2                 
  DDBClient.js         |       0 |      100 |       0 |       0 | 2-28              
 injection/metrics     |       0 |      100 |       0 |       0 |                   
  CloudWatchClient.js  |       0 |      100 |       0 |       0 | 2-69              
  MetricsClient.js     |       0 |      100 |     100 |       0 | 2                 
 metrics               |   83.33 |       50 |     100 |   83.33 |                   
  MetricsHelper.js     |   83.33 |       50 |     100 |   83.33 | 6                 
-----------------------|---------|----------|---------|---------|-------------------

Test Suites: 17 passed, 17 total
Tests:       72 passed, 72 total
Snapshots:   0 total
Time:        12.338 s
Ran all test suites.
```