### PR TITLE
Gen 2 migration Subtask 2: Prep CI/CD + integration test for alpha cutover

### DIFF
--- a/.github/workflows/backend-canary.yml
+++ b/.github/workflows/backend-canary.yml
@@ -28,22 +28,22 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: configure amplify
+      - name: generate amplify outputs
         run: |
-          npm install -g @aws-amplify/cli@13.0.1
-          aws_config_file_path="$(pwd)/aws_config_file_path.json"
-          echo '{"accessKeyId":"'$AWS_ACCESS_KEY_ID'","secretAccessKey":"'$AWS_SECRET_ACCESS_KEY'","region":"'$AWS_REGION'"}' > $aws_config_file_path
-          echo '{"projectPath": "'"$(pwd)"'","defaultEditor":"code","envName":"'alpha'"}' > ./amplify/.config/local-env-info.json
-          echo '{"'alpha'":{"configLevel":"project","useProfile":false,"awsConfigFilePath":"'$aws_config_file_path'"}}' > ./amplify/.config/local-aws-info.json
-          amplify env pull --yes
-          amplify status
+          npx ampx generate outputs --branch alpha --app-id "$GEN2_AMPLIFY_APP_ID"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
+          GEN2_AMPLIFY_APP_ID: ${{ secrets.GEN2_AMPLIFY_APP_ID }}
 
       - name: install, build and test (both unit and integ)
         run: |
           npm install
           npm run build
+          npm run build:gen2
           npm run test
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -6,7 +6,7 @@ on:
   # Triggers the workflow on push events but only for the master branch
   push:
     branches: [ master ]
-    paths: [ 'amplify/**' ]
+    paths: [ 'amplify/**', 'amplify-gen2/**' ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -31,29 +31,21 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: configure amplify
-        run: |
-          npm install -g @aws-amplify/cli@13.0.1
-          aws_config_file_path="$(pwd)/aws_config_file_path.json"
-          echo '{"accessKeyId":"'$AWS_ACCESS_KEY_ID'","secretAccessKey":"'$AWS_SECRET_ACCESS_KEY'","region":"'$AWS_REGION'"}' > $aws_config_file_path
-          echo '{"projectPath": "'"$(pwd)"'","defaultEditor":"code","envName":"'alpha'"}' > ./amplify/.config/local-env-info.json
-          echo '{"'alpha'":{"configLevel":"project","useProfile":false,"awsConfigFilePath":"'$aws_config_file_path'"}}' > ./amplify/.config/local-aws-info.json
-          amplify env pull --yes
-          amplify status
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-
       - name: install, build and unit test
         run: |
           npm install
           npm run build
+          npm run build:gen2
           npm run test:unit
 
       - name: deploy
         run: |
-          amplify push --yes
+          npx ampx pipeline-deploy --branch alpha --app-id "$GEN2_AMPLIFY_APP_ID"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          GEN2_AMPLIFY_APP_ID: ${{ secrets.GEN2_AMPLIFY_APP_ID }}
 
       - name: integration test
         run: |

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -30,6 +30,10 @@ jobs:
           npm run build
           npm run test:unit
 
+      - name: typecheck gen2
+        run: |
+          npx tsc --noEmit -p amplify-gen2/tsconfig.json
+
       - name: code coverage
         uses: artiomtr/jest-coverage-report-action@v2
         with:

--- a/amplify-gen2/backend.ts
+++ b/amplify-gen2/backend.ts
@@ -1,3 +1,4 @@
+import { Stack } from "aws-cdk-lib"
 import { defineBackend } from "@aws-amplify/backend"
 import { auth } from "./auth/resource"
 import { defineTables } from "./storage/tables"
@@ -15,15 +16,24 @@ import { defineSmsRouterFunction } from "./functions/smsrouter/resource"
 
 /**
  * Phase 4 complete: auth + all 7 storage tables + all 10 functions (9 API
- * handlers + smsrouter), mirroring Gen 1 alpha's full compute layer. Next
- * up per the migration plan: sandbox validation, then the alpha cutover.
+ * handlers + smsrouter), mirroring Gen 1 alpha's full compute layer.
+ * Phase 5 (alpha cutover): storage tables reference the existing Gen
+ * 1-created live tables by ARN (see storage/tables.ts) rather than
+ * declaring new CDK-managed ones, since cdk import isn't reachable
+ * through ampx's tooling and AWS's own Gen 2 migration guidance keeps
+ * DynamoDB tables external to the Gen 2 stack for exactly that reason.
  */
 const backend = defineBackend({
     auth,
 })
 
 const storageStack = backend.createStack("StorageStack")
-const tables = defineTables(storageStack, "alpha")
+const tables = defineTables(
+    storageStack,
+    Stack.of(storageStack).account,
+    Stack.of(storageStack).region,
+    "alpha"
+)
 
 const functionsStack = backend.createStack("FunctionsStack")
 defineAddItemFunction(functionsStack, tables)

--- a/amplify-gen2/functions/apiFunction.ts
+++ b/amplify-gen2/functions/apiFunction.ts
@@ -1,7 +1,7 @@
 import * as path from "path"
 import { Stack, Duration } from "aws-cdk-lib"
 import { Function, Runtime, Code } from "aws-cdk-lib/aws-lambda"
-import { Table } from "aws-cdk-lib/aws-dynamodb"
+import { ITable } from "aws-cdk-lib/aws-dynamodb"
 import { RmsTables } from "../storage/tables"
 
 /**
@@ -30,12 +30,12 @@ export function defineApiFunction(
         environment: Object.fromEntries(
             tableNames.map((name) => [
                 `STORAGE_${name.toUpperCase()}_NAME`,
-                (tables[name] as Table).tableName,
+                (tables[name] as ITable).tableName,
             ])
         ),
     })
 
-    tableNames.forEach((name) => (tables[name] as Table).grantReadWriteData(fn))
+    tableNames.forEach((name) => (tables[name] as ITable).grantReadWriteData(fn))
 
     return fn
 }

--- a/amplify-gen2/storage/tables.ts
+++ b/amplify-gen2/storage/tables.ts
@@ -1,52 +1,58 @@
 import { Stack } from "aws-cdk-lib"
-import { AttributeType, BillingMode, StreamViewType, Table } from "aws-cdk-lib/aws-dynamodb"
-import { RemovalPolicy } from "aws-cdk-lib"
+import { ITable, Table } from "aws-cdk-lib/aws-dynamodb"
 
 /**
- * Mirrors the 7 DynamoDB tables from amplify/backend/storage/*.
+ * References the 7 existing DynamoDB tables (created by Gen 1's Amplify
+ * CLI / CloudFormation, already holding live production data) by ARN,
+ * rather than declaring them as new CDK-managed `Table` constructs.
  *
- * Six tables (main, items, tags, batch, history, schedule) share an identical
- * shape: partition key "id" (String), streams enabled (NEW_AND_OLD_IMAGES).
- * transactions is the outlier: partition key "number", no streams.
+ * This is the AWS-documented pattern for connecting a Gen 2 backend to
+ * pre-existing DynamoDB tables (see "Connect to external Amazon DynamoDB
+ * data sources" in the Amplify docs) — the same pattern AWS's own
+ * official Gen 1 -> Gen 2 migration tooling uses for DynamoDB tables
+ * specifically. `cdk import`/CloudFormation's IMPORT change-set flow was
+ * evaluated and rejected: Amplify Gen 2's `ampx` tooling exposes no
+ * `cdk.json`/CDK CLI app and no synth-only escape hatch, so `cdk import`
+ * isn't reachable without hand-rolling unofficial scaffolding around it —
+ * not an acceptable risk against tables holding live data. Referencing by
+ * ARN means CloudFormation never issues Create/Update/Delete against the
+ * physical tables: the Gen 2 stack can be safely redeployed or even torn
+ * down without any risk to table data. The tradeoff is these tables stay
+ * unmanaged by CDK (no drift detection, no declarative schema changes),
+ * which matches this project's existing schemaless-DynamoDB approach
+ * (see ts-code/src/db/Schemas.ts) — TypeScript interfaces, not CDK/CFN,
+ * are already the source of truth for table shape here.
  *
- * RemovalPolicy.RETAIN on every table is non-negotiable — this is live data.
+ * Six tables (main, items, tags, batch, history, schedule) share an
+ * identical shape: partition key "id" (String), streams enabled
+ * (NEW_AND_OLD_IMAGES). transactions is the outlier: partition key
+ * "number", no streams. (Both facts are informational only now — the
+ * live tables already have this shape; nothing here declares it.)
  */
 export interface RmsTables {
-    main: Table
-    items: Table
-    tags: Table
-    batch: Table
-    history: Table
-    schedule: Table
-    transactions: Table
+    main: ITable
+    items: ITable
+    tags: ITable
+    batch: ITable
+    history: ITable
+    schedule: ITable
+    transactions: ITable
 }
 
 const UNIFORM_TABLE_NAMES = ["main", "items", "tags", "batch", "history", "schedule"] as const
 
-export function defineTables(stack: Stack, envSuffix: string): RmsTables {
+export function defineTables(stack: Stack, awsAccountId: string, awsRegion: string, envSuffix: string): RmsTables {
+    const tableArn = (name: string) =>
+        `arn:aws:dynamodb:${awsRegion}:${awsAccountId}:table/${name}-${envSuffix}`
+
     const uniformTables = Object.fromEntries(
         UNIFORM_TABLE_NAMES.map((name) => [
             name,
-            new Table(stack, `${capitalize(name)}Table`, {
-                tableName: `${name}-${envSuffix}`,
-                partitionKey: { name: "id", type: AttributeType.STRING },
-                stream: StreamViewType.NEW_AND_OLD_IMAGES,
-                billingMode: BillingMode.PROVISIONED,
-                readCapacity: 1,
-                writeCapacity: 1,
-                removalPolicy: RemovalPolicy.RETAIN,
-            }),
+            Table.fromTableArn(stack, `${capitalize(name)}Table`, tableArn(name)),
         ])
-    ) as Record<(typeof UNIFORM_TABLE_NAMES)[number], Table>
+    ) as Record<(typeof UNIFORM_TABLE_NAMES)[number], ITable>
 
-    const transactions = new Table(stack, "TransactionsTable", {
-        tableName: `transactions-${envSuffix}`,
-        partitionKey: { name: "number", type: AttributeType.STRING },
-        billingMode: BillingMode.PROVISIONED,
-        readCapacity: 1,
-        writeCapacity: 1,
-        removalPolicy: RemovalPolicy.RETAIN,
-    })
+    const transactions = Table.fromTableArn(stack, "TransactionsTable", tableArn("transactions"))
 
     return { ...uniformTables, transactions }
 }

--- a/ts-code/__tests__/integration/Amplify.test.ts
+++ b/ts-code/__tests__/integration/Amplify.test.ts
@@ -1,31 +1,34 @@
 import { Amplify } from 'aws-amplify'
-import { AuthSession, fetchAuthSession, signIn, SignInOutput, signOut } from 'aws-amplify/auth';
+import { AuthSession, fetchAuthSession, signIn, signUp, SignInOutput, signOut } from 'aws-amplify/auth';
 import { InvokeCommandOutput, Lambda } from '@aws-sdk/client-lambda';
 import { TestConstants, TestTimestamps } from "../../__dev__/db/DBTestConstants"
-const awsExports = require('../../../../src/aws-exports').default
+const amplifyOutputs = require('../../../../amplify_outputs.json')
 
 const ENV_SUFFIX = '-alpha'
 
 describe('Amplify Tests', () => {
     beforeAll(async () => {
-        Amplify.configure(awsExports)
-    })
+        Amplify.configure(amplifyOutputs)
 
-    /**
-     * One time use. Leaving here for completeness.
-     * 
-    test('will sign up when api is called', async () => {
-        await expect(
-            signUp({
-            username: TestConstants.EMAIL,
-            password: TestConstants.PASSWORD,
-            options: { userAttributes: {
-                email: TestConstants.EMAIL,
-                name: TestConstants.OWNER
-            } }
-        })).resolves
+        // The Gen 2 Cognito pool starts with no users, unlike Gen 1's
+        // preserved pool, so ensure the test user exists on every run.
+        // Ignore "already exists" so repeat runs against the same pool
+        // don't fail the suite.
+        try {
+            await signUp({
+                username: TestConstants.EMAIL,
+                password: TestConstants.PASSWORD,
+                options: { userAttributes: {
+                    email: TestConstants.EMAIL,
+                    name: TestConstants.OWNER
+                } }
+            })
+        } catch (error) {
+            if (!(error instanceof Error) || error.name !== 'UsernameExistsException') {
+                throw error
+            }
+        }
     })
-     */
 
     /**
      * AUTH: Sign In
@@ -47,7 +50,7 @@ describe('Amplify Tests', () => {
         const authSession: AuthSession = await fetchAuthSession()
         const lambda = new Lambda({
             credentials: authSession.credentials,
-            region: awsExports.aws_project_region
+            region: amplifyOutputs.auth.aws_region
         })
 
         // Add Item


### PR DESCRIPTION
## Status: prep complete, ready to merge

AWS credentials became available after this PR was opened, so the remaining runbook steps below have been completed directly. **This PR is now ready to merge** — merging fires `backend-cd.yml`'s `ampx pipeline-deploy` step against the live `alpha` account (the actual Lambda deploy step of this migration).

## Summary
- `backend-cd.yml` / `backend-canary.yml`: replaced the hand-rolled Gen 1 Amplify CLI bootstrap (`amplify env pull --yes`, `amplify push --yes`, hand-written `local-env-info.json`/`local-aws-info.json`) with `ampx pipeline-deploy` / `ampx generate outputs`, using a new `GEN2_AMPLIFY_APP_ID` secret. `backend-cd.yml`'s trigger paths now include `amplify-gen2/**` alongside the existing `amplify/**`.
- `backend-ci.yml`: added a credential-less `npx tsc --noEmit -p amplify-gen2/tsconfig.json` step to catch Gen 2 CDK errors pre-merge.
- `ts-code/__tests__/integration/Amplify.test.ts`: swapped `aws-exports.js` (Gen 1) for `amplify_outputs.json` (Gen 2, nested `auth.aws_region` shape). Added a `signUp` step in `beforeAll` (tolerating `UsernameExistsException`) since the fresh Gen 2 Cognito pool has no pre-existing users. `ENV_SUFFIX`/`FunctionName` strings unchanged (#293 already named all 10 Gen 2 Lambdas `<PascalName>-alpha`, matching Gen 1).
- **`amplify-gen2/storage/tables.ts` — architecture change from the original plan**: switched from `new dynamodb.Table(...)` (CDK-owned) to `Table.fromTableArn(...)` (unmanaged reference to the existing live tables). Original plan called for `cdk import`, but research confirmed that's not reachable through `ampx`'s tooling (no `cdk.json`/CDK CLI app exposed, no synth-only escape hatch) — and AWS's own official Gen 1→Gen 2 migration tooling deliberately keeps DynamoDB tables external to the Gen 2 stack for the same reason, using this exact "connect to existing DynamoDB table" pattern. CloudFormation will never issue Create/Update/Delete against the physical tables under this approach — materially safer for live production data, at the cost of CDK-level drift detection (acceptable: `ts-code/src/db/Schemas.ts` is already this project's schema source of truth, not CDK). `RmsTables`/`apiFunction.ts` now type against `ITable` instead of the concrete `Table` class.

Part of #292 (Gen 1 → Gen 2 rebuild), depends on #293 (merged). Full context: `.claude/plans/can-you-make-a-shimmying-crane.md`.

## Runbook — completed steps
1. ✅ Provisioned Gen 2 Amplify app `rms-gen2` (app ID `d2t4r8ycfq1um5`) with an `alpha` branch. Added `GEN2_AMPLIFY_APP_ID` as a repo secret in the `AmplifyCD` GitHub environment.
2. ✅ Took on-demand DynamoDB backups of all 7 live tables in `alpha` (`main-alpha`, `items-alpha`, `tags-alpha`, `batch-alpha`, `history-alpha`, `schedule-alpha`, `transactions-alpha`) — all confirmed `AVAILABLE`, tagged `*-pre-gen2-cutover-20260730`.
3. ~~`cdk import` the 7 live tables~~ — **superseded**: switched to `Table.fromTableArn` referencing instead (see architecture change above). No import needed; the tables were never going to be recreated or touched.

## Runbook — remaining steps
4. **Merge this PR** — fires the new `ampx pipeline-deploy` step, deploying the 10 Gen 2 Lambdas (referencing the existing live tables) into the new stack.
5. Send a real test SMS through `smsrouter` (or invoke it directly — no SNS trigger) to confirm end-to-end function.
6. Bake 1–2 weeks with `backend-canary.yml` green before starting #295 (decommission Gen 1).

## Test plan
- [x] `npx tsc --noEmit -p amplify-gen2/tsconfig.json` — clean
- [x] `npm run build` + `npm run build:gen2` + `npm run test:unit` — 27/27 suites, 98/98 tests pass, coverage unaffected (no `ts-code/src` changes)
- [x] Confirmed the rewritten integration test compiles correctly into `amplify/ts-output/__tests__/integration/Amplify.test.js`
- [x] YAML-validated all three workflow files
- [x] Verified AWS credentials resolve to the correct account (`801118485191`, `us-west-2`)
- [x] Confirmed all 7 live table names match what `tables.ts` now references by ARN
- [ ] Post-merge: confirm `ampx pipeline-deploy` succeeds and the 10 Lambdas deploy correctly against the referenced tables

Refs #294
