### PR TITLE
GH-305: Cognito Google Workspace SSO (restricted to acts2.network)

### DIFF
--- a/amplify/auth/resource.ts
+++ b/amplify/auth/resource.ts
@@ -1,4 +1,5 @@
-import { defineAuth } from "@aws-amplify/backend"
+import { defineAuth, defineFunction, secret } from "@aws-amplify/backend"
+import { definePreSignUpFunction } from "../functions/pre-sign-up/resource"
 
 /**
  * Fresh Cognito User Pool, replacing the Gen 1 pool
@@ -11,17 +12,59 @@ import { defineAuth } from "@aws-amplify/backend"
  * API allows: email/password login, email + name required attributes,
  * MFA off. Since this is a fresh pool, all users will need to sign up
  * again — there is no data to migrate.
+ *
+ * Google federation is restricted to acts2.network Workspace accounts:
+ * Google's own OIDC docs require the relying party to check the signed
+ * `hd` claim server-side (Google Cloud Console's "Internal" app-type
+ * restriction alone isn't reliable across orgs), so the actual
+ * enforcement is the preSignUp trigger below, not anything on the
+ * Google side. clientId/clientSecret reference Amplify secrets (set via
+ * `ampx sandbox secret set GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`) --
+ * real values are provided out of band, not committed here.
+ *
+ * callbackUrls/logoutUrls are localhost:3000 placeholders until the
+ * web/ frontend (#303) exists and is deployed -- append the real prod
+ * URL then, no redeploy dance needed since these are plain arrays.
+ * domainPrefix isn't exposed at the defineAuth factory layer in this
+ * Amplify version (confirmed via the installed package's own types --
+ * ExternalProviderGeneralFactoryProps explicitly omits it, and
+ * AmplifyAuthProps never re-adds it) -- Amplify computes the Hosted UI
+ * domain prefix automatically, so no need to set it here.
  */
 export const auth = defineAuth({
     loginWith: {
         email: true,
+        externalProviders: {
+            google: {
+                clientId: secret("GOOGLE_CLIENT_ID"),
+                clientSecret: secret("GOOGLE_CLIENT_SECRET"),
+                attributeMapping: {
+                    custom: {
+                        hd: "hd",
+                    },
+                },
+            },
+            callbackUrls: ["http://localhost:3000/callback"],
+            logoutUrls: ["http://localhost:3000/"],
+        },
     },
     userAttributes: {
         fullname: {
             required: true,
         },
+        "custom:hd": {
+            dataType: "String",
+            mutable: true,
+            maxLen: 253,
+        },
     },
     multifactor: {
         mode: "OFF",
+    },
+    triggers: {
+        preSignUp: defineFunction(
+            (scope) => definePreSignUpFunction(scope),
+            { resourceGroupName: "auth" }
+        ),
     },
 })

--- a/amplify/functions/apiFunction.ts
+++ b/amplify/functions/apiFunction.ts
@@ -5,13 +5,24 @@ import { ITable } from "aws-cdk-lib/aws-dynamodb"
 import { RmsTables } from "../storage/tables"
 
 /**
+ * Every Gen 2 Lambda in this repo (API handlers, the Cognito Pre Sign-up
+ * trigger, ...) is a plain lambda.Function (not NodejsFunction) pointed
+ * at backend-build-gen2.js's pre-compiled output for its own function
+ * directory, since the shared ts-code/ source is compiled once outside
+ * CDK, not per-function via esbuild. Shared here so each function's
+ * resource.ts only states its own timeout/handler/dependencies.
+ */
+export function functionCode(functionDir: string): Code {
+    return Code.fromAsset(path.join(process.cwd(), "amplify", "functions", functionDir, "build"))
+}
+
+/**
  * Shared "custom function" CDK construct builder for the Gen 1 -> Gen 2
- * rebuild's Lambdas. Every function is a plain lambda.Function (not
- * NodejsFunction) pointed at backend-build-gen2.js's pre-compiled output,
- * since the shared ts-code/ source is compiled once outside CDK, not
- * per-function via esbuild. Table env vars + grants are derived from
- * amplify/backend/backend-config.json's per-function dependsOn list,
- * passed in as `tableNames`.
+ * rebuild's API Lambdas specifically -- adds DynamoDB table env vars +
+ * grants, derived from amplify/backend/backend-config.json's per-function
+ * dependsOn list, passed in as `tableNames`. Functions with no table
+ * dependency (e.g. the Cognito Pre Sign-up trigger) build the Function
+ * construct directly using functionCode(...) above instead of this.
  */
 export function defineApiFunction(
     stack: Stack,
@@ -25,7 +36,7 @@ export function defineApiFunction(
         functionName: `${functionName}-alpha`,
         runtime: Runtime.NODEJS_22_X,
         handler,
-        code: Code.fromAsset(path.join(process.cwd(), "amplify", "functions", functionDir, "build")),
+        code: functionCode(functionDir),
         timeout: Duration.seconds(25),
         environment: Object.fromEntries(
             tableNames.map((name) => [

--- a/amplify/functions/pre-sign-up/resource.ts
+++ b/amplify/functions/pre-sign-up/resource.ts
@@ -1,7 +1,7 @@
-import * as path from "path"
 import { Construct } from "constructs"
 import { Duration } from "aws-cdk-lib"
-import { Function, Runtime, Code } from "aws-cdk-lib/aws-lambda"
+import { Function, Runtime } from "aws-cdk-lib/aws-lambda"
+import { functionCode } from "../apiFunction"
 
 /**
  * Minimal CDK function construct for the Cognito Pre Sign-up trigger.
@@ -17,7 +17,7 @@ export function definePreSignUpFunction(scope: Construct): Function {
         functionName: "pre-sign-up-alpha",
         runtime: Runtime.NODEJS_22_X,
         handler: "handlers/auth/PreSignUp.handler",
-        code: Code.fromAsset(path.join(process.cwd(), "amplify", "functions", "pre-sign-up", "build")),
+        code: functionCode("pre-sign-up"),
         timeout: Duration.seconds(10),
     })
 }

--- a/amplify/functions/pre-sign-up/resource.ts
+++ b/amplify/functions/pre-sign-up/resource.ts
@@ -1,0 +1,23 @@
+import * as path from "path"
+import { Construct } from "constructs"
+import { Duration } from "aws-cdk-lib"
+import { Function, Runtime, Code } from "aws-cdk-lib/aws-lambda"
+
+/**
+ * Minimal CDK function construct for the Cognito Pre Sign-up trigger.
+ * Unlike apiFunction.ts's defineApiFunction, this needs no DynamoDB table
+ * env vars or grants -- it only inspects the incoming Cognito event. Built
+ * via defineFunction's provider-callback overload (see auth/resource.ts),
+ * so `scope` is supplied by Amplify's construct container at synth time,
+ * not a manually-created Stack -- matches defineFunction's
+ * `(scope: Construct) => IFunction` signature exactly.
+ */
+export function definePreSignUpFunction(scope: Construct): Function {
+    return new Function(scope, "PreSignUpFunction", {
+        functionName: "pre-sign-up-alpha",
+        runtime: Runtime.NODEJS_22_X,
+        handler: "handlers/auth/PreSignUp.handler",
+        code: Code.fromAsset(path.join(process.cwd(), "amplify", "functions", "pre-sign-up", "build")),
+        timeout: Duration.seconds(10),
+    })
+}

--- a/backend-build-gen2.js
+++ b/backend-build-gen2.js
@@ -100,6 +100,13 @@ exec(`tsc --project tsconfig.gen1.json --outDir ${TS_OUTPUT_PATH}`, { cwd: REPO_
             smsrouterBuild
         )
 
+        const preSignUpBuildDir = path.join(GEN2_FUNCTIONS_PATH, "pre-sign-up", "build")
+        copySingleFile(
+            path.join(TS_OUTPUT_PATH, "src", "handlers", "auth"),
+            path.join(preSignUpBuildDir, "handlers", "auth"),
+            "PreSignUp"
+        )
+
         API_NAMES.forEach((apiName) => {
             const buildDir = path.join(GEN2_FUNCTIONS_PATH, kebabCase(apiName), "build")
 

--- a/ts-code/__tests__/unit/handlers/auth/PreSignUp.test.ts
+++ b/ts-code/__tests__/unit/handlers/auth/PreSignUp.test.ts
@@ -1,0 +1,32 @@
+import { PreSignUpExternalProviderTriggerEvent } from "aws-lambda"
+import { handler } from "../../../../src/handlers/auth/PreSignUp"
+
+function buildEvent(userAttributes: { [key: string]: string }): PreSignUpExternalProviderTriggerEvent {
+    return {
+        triggerSource: "PreSignUp_ExternalProvider",
+        request: { userAttributes },
+        response: { autoConfirmUser: false, autoVerifyEmail: false, autoVerifyPhone: false },
+    } as PreSignUpExternalProviderTriggerEvent
+}
+
+test('will allow sign-up when hd claim matches acts2.network', async () => {
+    const event = buildEvent({ "custom:hd": "acts2.network" })
+
+    await expect(handler(event, null as any, null as any)).resolves.toEqual(event)
+})
+
+test('will reject sign-up when hd claim is a different domain', async () => {
+    const event = buildEvent({ "custom:hd": "gmail.com" })
+
+    await expect(handler(event, null as any, null as any)).rejects.toThrow(
+        "Sign-up restricted to acts2.network Google Workspace accounts"
+    )
+})
+
+test('will reject sign-up when hd claim is missing entirely', async () => {
+    const event = buildEvent({})
+
+    await expect(handler(event, null as any, null as any)).rejects.toThrow(
+        "Sign-up restricted to acts2.network Google Workspace accounts"
+    )
+})

--- a/ts-code/src/handlers/auth/PreSignUp.ts
+++ b/ts-code/src/handlers/auth/PreSignUp.ts
@@ -1,0 +1,14 @@
+import { PreSignUpTriggerHandler } from "aws-lambda"
+
+const ALLOWED_HOSTED_DOMAIN = "acts2.network"
+
+export const handler: PreSignUpTriggerHandler = async (event) => {
+    if (event.triggerSource === "PreSignUp_ExternalProvider") {
+        const hostedDomain = event.request.userAttributes["custom:hd"]
+        if (hostedDomain !== ALLOWED_HOSTED_DOMAIN) {
+            throw new Error(`Sign-up restricted to ${ALLOWED_HOSTED_DOMAIN} Google Workspace accounts`)
+        }
+    }
+
+    return event
+}


### PR DESCRIPTION
## Summary
- Extends `amplify/auth/resource.ts`'s `defineAuth` with Google as a federated Cognito login provider (`loginWith.externalProviders.google`), with `clientId`/`clientSecret` referenced as named Amplify secrets (`GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`) rather than committed values.
- Adds a new Cognito Pre Sign-up Lambda trigger (`ts-code/src/handlers/auth/PreSignUp.ts` + `amplify/functions/pre-sign-up/resource.ts`) that rejects any Google-federated sign-up whose `hd` (hosted domain) claim isn't `acts2.network` — including accounts with no `hd` claim at all. This is the actual enforcement point; Google Cloud Console's own domain restriction isn't reliable across orgs (confirmed via Google's OIDC docs during triage, see issue #305).
- Maps Google's `hd` claim to a new `custom:hd` Cognito user pool attribute via `attributeMapping.custom`.
- Wires the trigger via `defineFunction`'s provider-callback overload (`defineAuth`'s `triggers.preSignUp` needs a `ConstructFactory`, not the raw CDK `Function` this repo's existing Lambda pattern returns directly).
- Adds a new special-case block to `backend-build-gen2.js` (mirrors the existing `smsrouter` block) to fan the trigger's compiled output into its own function build directory, since that script doesn't auto-discover handlers.
- Native email/password sign-up (`loginWith.email`) is untouched — only the Google-federated path is domain-gated.

Part of the new-frontend epic (#303), second of 3 sub-issues (#304 merged, #305 this PR, #306 remaining).

## Known follow-ups (not blocking this PR)
- Real `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` values need to be set by the repo owner via `ampx sandbox secret set GOOGLE_CLIENT_ID` / `ampx sandbox secret set GOOGLE_CLIENT_SECRET` (interactive, run locally) before Google sign-in works end-to-end.
- `callbackUrls`/`logoutUrls` currently point at `localhost:3000` placeholders — append the real production URL once `web/` (#303/#306) is built and deployed.

## Test plan
- [x] New `ts-code/__tests__/unit/handlers/auth/PreSignUp.test.ts`: accepts `acts2.network`, rejects other domains, rejects missing `hd` claim
- [x] `npm run build` — ts-code compiles
- [x] `npm run test:unit` — 32 suites / 111 tests pass, 91%+ coverage (above the 80% floor)
- [x] `npm run build:gen2` — confirms `amplify/functions/pre-sign-up/build/handlers/auth/PreSignUp.js` is produced
- [x] `npx tsc --noEmit -p amplify/tsconfig.json` — CDK code typechecks (caught and fixed two real type mismatches against the actual installed Amplify types: `attributeMapping.custom` takes plain strings not `ProviderAttribute`, and `domainPrefix` isn't exposed at the `defineAuth` factory layer in this Amplify version — Amplify computes it automatically)
- [ ] Live verification: per this repo's deploy-verification policy (CLAUDE.md), no `ampx sandbox` run — will verify via `backend-cd.yml`'s post-merge alpha deploy + `npm run test:integ` after merge, before closing #305

Refs #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)
