### PR TITLE
Fix GH-305: Google SSO domain check via email, not unsupported hd claim

### DIFF
--- a/amplify/auth/resource.ts
+++ b/amplify/auth/resource.ts
@@ -13,14 +13,26 @@ import { definePreSignUpFunction } from "../functions/pre-sign-up/resource"
  * MFA off. Since this is a fresh pool, all users will need to sign up
  * again — there is no data to migrate.
  *
- * Google federation is restricted to acts2.network Workspace accounts:
- * Google's own OIDC docs require the relying party to check the signed
- * `hd` claim server-side (Google Cloud Console's "Internal" app-type
- * restriction alone isn't reliable across orgs), so the actual
- * enforcement is the preSignUp trigger below, not anything on the
- * Google side. clientId/clientSecret reference Amplify secrets (set via
- * `ampx sandbox secret set GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`) --
- * real values are provided out of band, not committed here.
+ * Google federation is restricted to acts2.network Workspace accounts.
+ * Google's `hd` (hosted domain) claim only exists on the raw ID token --
+ * Cognito's Google IdP integration fetches user info via Google's People
+ * API instead (confirmed via its ProviderDetails.attributes_url), which
+ * doesn't expose `hd` at all, so it can't be used as an attributeMapping
+ * source (verified against a real deploy: Cognito rejects it outright
+ * with "AttributeMapping contains invalid mapping: [hd]"). The
+ * documented, working alternative (AWS's own Pre Sign-up trigger docs,
+ * and the common "Google Sign-In with an allowlist" pattern) is to
+ * check the mapped `email` attribute's domain suffix instead -- `email`
+ * is a real People API field and needs no custom attribute or extra
+ * mapping: with loginWith.email enabled and no phone login, Amplify's
+ * defineAuth automatically maps Google's email to the standard `email`
+ * attribute already. See ts-code/src/handlers/auth/PreSignUp.ts.
+ *
+ * clientId/clientSecret reference Amplify secrets (set via the Amplify
+ * Console's per-branch secrets, or SSM directly at
+ * /amplify/<app-id>/<branch>-branch-<hash>/<name> for branches without
+ * a connected Hosting repo) -- real values are provided out of band,
+ * not committed here.
  *
  * callbackUrls/logoutUrls are localhost:3000 placeholders until the
  * web/ frontend (#303) exists and is deployed -- append the real prod
@@ -38,11 +50,6 @@ export const auth = defineAuth({
             google: {
                 clientId: secret("GOOGLE_CLIENT_ID"),
                 clientSecret: secret("GOOGLE_CLIENT_SECRET"),
-                attributeMapping: {
-                    custom: {
-                        hd: "hd",
-                    },
-                },
             },
             callbackUrls: ["http://localhost:3000/callback"],
             logoutUrls: ["http://localhost:3000/"],
@@ -51,11 +58,6 @@ export const auth = defineAuth({
     userAttributes: {
         fullname: {
             required: true,
-        },
-        "custom:hd": {
-            dataType: "String",
-            mutable: true,
-            maxLen: 253,
         },
     },
     multifactor: {

--- a/ts-code/__tests__/unit/handlers/auth/PreSignUp.test.ts
+++ b/ts-code/__tests__/unit/handlers/auth/PreSignUp.test.ts
@@ -9,21 +9,21 @@ function buildEvent(userAttributes: { [key: string]: string }): PreSignUpExterna
     } as PreSignUpExternalProviderTriggerEvent
 }
 
-test('will allow sign-up when hd claim matches acts2.network', async () => {
-    const event = buildEvent({ "custom:hd": "acts2.network" })
+test('will allow sign-up when email domain matches acts2.network', async () => {
+    const event = buildEvent({ email: "jane@acts2.network" })
 
     await expect(handler(event, null as any, null as any)).resolves.toEqual(event)
 })
 
-test('will reject sign-up when hd claim is a different domain', async () => {
-    const event = buildEvent({ "custom:hd": "gmail.com" })
+test('will reject sign-up when email domain is different', async () => {
+    const event = buildEvent({ email: "jane@gmail.com" })
 
     await expect(handler(event, null as any, null as any)).rejects.toThrow(
         "Sign-up restricted to acts2.network Google Workspace accounts"
     )
 })
 
-test('will reject sign-up when hd claim is missing entirely', async () => {
+test('will reject sign-up when email is missing entirely', async () => {
     const event = buildEvent({})
 
     await expect(handler(event, null as any, null as any)).rejects.toThrow(

--- a/ts-code/src/handlers/auth/PreSignUp.ts
+++ b/ts-code/src/handlers/auth/PreSignUp.ts
@@ -1,12 +1,13 @@
 import { PreSignUpTriggerHandler } from "aws-lambda"
 
-const ALLOWED_HOSTED_DOMAIN = "acts2.network"
+const ALLOWED_EMAIL_DOMAIN = "acts2.network"
 
 export const handler: PreSignUpTriggerHandler = async (event) => {
     if (event.triggerSource === "PreSignUp_ExternalProvider") {
-        const hostedDomain = event.request.userAttributes["custom:hd"]
-        if (hostedDomain !== ALLOWED_HOSTED_DOMAIN) {
-            throw new Error(`Sign-up restricted to ${ALLOWED_HOSTED_DOMAIN} Google Workspace accounts`)
+        const email = event.request.userAttributes.email
+        const domain = email?.split("@")[1]
+        if (domain !== ALLOWED_EMAIL_DOMAIN) {
+            throw new Error(`Sign-up restricted to ${ALLOWED_EMAIL_DOMAIN} Google Workspace accounts`)
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes a real deploy failure discovered after merging #308 (GH-305: Cognito Google Workspace SSO). The original approach mapped Google's `hd` (hosted domain) claim to a custom `custom:hd` user pool attribute for the Pre Sign-up trigger to check — this failed at deploy time with:

```
AttributeMapping contains invalid mapping: [hd] (Service: CognitoIdentityProvider, Status Code: 400 ...)
```

**Root cause**: `hd` only exists on Google's raw OIDC ID token. Cognito's Google IdP integration fetches user profile data via Google's **People API** instead (confirmed via `ProviderDetails.attributes_url` in AWS's own CFN docs), and the People API doesn't expose `hd` at all — so it can never be a valid `attributeMapping` source for Cognito's Google IdP, regardless of syntax.

**Fix**: switch to the documented, working pattern (AWS's own Pre Sign-up trigger docs, and the common "Google Sign-In with an email allowlist" approach) — check the mapped `email` attribute's domain suffix instead of a custom `hd` attribute. `email` is a real People API field and needs no custom attribute or extra `attributeMapping` config at all: with `loginWith.email` enabled and no phone login, Amplify's `defineAuth` already auto-maps Google's email to the standard `email` attribute.

This also simplifies the implementation: removes the `custom:hd` user pool attribute and its `attributeMapping.custom` config entirely.

## Root cause discovery
Found via a live deploy attempt against `alpha` (after setting real `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` secrets) — the stack briefly entered `UPDATE_ROLLBACK_FAILED` twice during this investigation (once from the missing-secrets issue, once from this attribute-mapping issue) but was recovered cleanly both times via `aws cloudformation continue-update-rollback` with the correct nested-stack resource skip syntax (`ParentStackName` + `--resources-to-skip <PhysicalNestedStackName>.<ResourceLogicalId>`, restricted to resources in `UPDATE_FAILED` state). No data loss — the Cognito user pool and its data were never actually touched by either failed deploy.

## Test plan
- [x] Updated `ts-code/__tests__/unit/handlers/auth/PreSignUp.test.ts`: accept `@acts2.network` email, reject other domain, reject missing email
- [x] `npm run build` — compiles
- [x] `npm run test:unit` — 32 suites / 111 tests pass, 91%+ coverage
- [x] `npm run build:gen2` — fans out correctly
- [x] `npx tsc --noEmit -p amplify/tsconfig.json` — typechecks
- [ ] Live verification: per this repo's deploy-verification policy, will verify via `backend-cd.yml`'s post-merge alpha deploy + `npm run test:integ` after merge, before closing #305

Refs #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)
