### PR TITLE
Fix GH-305: map fullname to Google's name claim

### DIFF
--- a/amplify/auth/resource.ts
+++ b/amplify/auth/resource.ts
@@ -28,6 +28,13 @@ import { definePreSignUpFunction } from "../functions/pre-sign-up/resource"
  * defineAuth automatically maps Google's email to the standard `email`
  * attribute already. See ts-code/src/handlers/auth/PreSignUp.ts.
  *
+ * `fullname` still needs an explicit attributeMapping to Google's "name"
+ * claim: Amplify only auto-maps `email`, and this pool requires
+ * `fullname` (below) -- omitting it fails at deploy time with "The
+ * attribute mapping is missing required attributes [name]" (verified
+ * against a real deploy), since Cognito can't populate a required
+ * attribute for a federated sign-up with no mapped source.
+ *
  * clientId/clientSecret reference Amplify secrets (set via the Amplify
  * Console's per-branch secrets, or SSM directly at
  * /amplify/<app-id>/<branch>-branch-<hash>/<name> for branches without
@@ -50,6 +57,9 @@ export const auth = defineAuth({
             google: {
                 clientId: secret("GOOGLE_CLIENT_ID"),
                 clientSecret: secret("GOOGLE_CLIENT_SECRET"),
+                attributeMapping: {
+                    fullname: "name",
+                },
             },
             callbackUrls: ["http://localhost:3000/callback"],
             logoutUrls: ["http://localhost:3000/"],


### PR DESCRIPTION
## Summary
Second follow-up fix for #305's Google SSO deploy. #309's `hd`→`email` fix removed the `attributeMapping` config entirely, but that broke the deploy differently: this user pool requires a `fullname` attribute (`userAttributes.fullname.required = true`), and Amplify's `defineAuth` only auto-maps `email` for external providers, not `name`/`fullname`. Cognito rejected the Google IdP resource at deploy time with:

```
The attribute mapping is missing required attributes [name] (Service: CognitoIdentityProvider, Status Code: 400 ...)
```

**Fix**: adds back a minimal `attributeMapping: { fullname: "name" }` (mapping Google's `name` claim, a real People API field, to the pool's required `fullname` attribute) — much narrower than the original broken `hd`-based mapping, and doesn't reintroduce any of the `custom:hd`/People-API issues from #309.

Both stacks (parent + nested auth) auto-recovered cleanly from this deploy's rollback with no manual CloudFormation intervention needed this time.

## Test plan
- [x] `npx tsc --noEmit -p amplify/tsconfig.json` — typechecks
- [x] `npm run test:unit` — 32 suites / 111 tests pass, 91%+ coverage (no test changes needed, this is CDK-config-only)
- [x] `npm run build:gen2` — fans out correctly
- [ ] Live verification: will verify via `backend-cd.yml`'s post-merge alpha deploy + `npm run test:integ` after merge, before closing #305

Refs #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)
