### PR TITLE
GH-306 (PR 1/4): Add read/list HTTP routes for the web/ frontend

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
     "env": {
         "browser": true,
+        "node": true,
         "es2021": true
     },
     "extends": [

--- a/amplify/api/resource.ts
+++ b/amplify/api/resource.ts
@@ -1,4 +1,4 @@
-import { Stack } from "aws-cdk-lib"
+import { CfnOutput, Stack } from "aws-cdk-lib"
 import {
     RestApi,
     LambdaIntegration,
@@ -19,6 +19,12 @@ export interface ApiFunctions {
     deleteReservation: Function
     returnItem: Function
     updateTags: Function
+    getItem: Function
+    searchItem: Function
+    getReservation: Function
+    getBatch: Function
+    listItems: Function
+    listReservations: Function
 }
 
 export function defineApiGateway(stack: Stack, userPool: IUserPool, functions: ApiFunctions): RestApi {
@@ -41,6 +47,12 @@ export function defineApiGateway(stack: Stack, userPool: IUserPool, functions: A
         ["delete-reservation", functions.deleteReservation],
         ["return-item", functions.returnItem],
         ["update-tags", functions.updateTags],
+        ["get-item", functions.getItem],
+        ["search-item", functions.searchItem],
+        ["get-reservation", functions.getReservation],
+        ["get-batch", functions.getBatch],
+        ["list-items", functions.listItems],
+        ["list-reservations", functions.listReservations],
     ]
 
     routes.forEach(([path, fn]) => {
@@ -49,6 +61,11 @@ export function defineApiGateway(stack: Stack, userPool: IUserPool, functions: A
             authorizationType: AuthorizationType.COGNITO,
         })
     })
+
+    // Amplify's `ampx generate outputs` doesn't surface a custom RestApi's
+    // invoke URL - the web/ frontend (GH-306) needs this output to
+    // discover the API endpoint at build time.
+    new CfnOutput(stack, "ApiUrl", { value: api.url })
 
     return api
 }

--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -13,6 +13,12 @@ import { defineDeleteReservationFunction } from "./functions/delete-reservation/
 import { defineReturnItemFunction } from "./functions/return-item/resource"
 import { defineUpdateTagsFunction } from "./functions/update-tags/resource"
 import { defineSmsRouterFunction } from "./functions/smsrouter/resource"
+import { defineGetItemFunction } from "./functions/get-item/resource"
+import { defineSearchItemFunction } from "./functions/search-item/resource"
+import { defineGetReservationFunction } from "./functions/get-reservation/resource"
+import { defineGetBatchFunction } from "./functions/get-batch/resource"
+import { defineListItemsFunction } from "./functions/list-items/resource"
+import { defineListReservationsFunction } from "./functions/list-reservations/resource"
 import { defineApiGateway } from "./api/resource"
 
 /**
@@ -47,6 +53,12 @@ const deleteItemFn = defineDeleteItemFunction(functionsStack, tables)
 const deleteReservationFn = defineDeleteReservationFunction(functionsStack, tables)
 const returnItemFn = defineReturnItemFunction(functionsStack, tables)
 const updateTagsFn = defineUpdateTagsFunction(functionsStack, tables)
+const getItemFn = defineGetItemFunction(functionsStack, tables)
+const searchItemFn = defineSearchItemFunction(functionsStack, tables)
+const getReservationFn = defineGetReservationFunction(functionsStack, tables)
+const getBatchFn = defineGetBatchFunction(functionsStack, tables)
+const listItemsFn = defineListItemsFunction(functionsStack, tables)
+const listReservationsFn = defineListReservationsFunction(functionsStack, tables)
 defineSmsRouterFunction(functionsStack, tables)
 
 const apiStack = backend.createStack("ApiStack")
@@ -61,4 +73,10 @@ defineApiGateway(apiStack, backend.auth.resources.userPool, {
     deleteReservation: deleteReservationFn,
     returnItem: returnItemFn,
     updateTags: updateTagsFn,
+    getItem: getItemFn,
+    searchItem: searchItemFn,
+    getReservation: getReservationFn,
+    getBatch: getBatchFn,
+    listItems: listItemsFn,
+    listReservations: listReservationsFn,
 })

--- a/amplify/functions/get-batch/resource.ts
+++ b/amplify/functions/get-batch/resource.ts
@@ -1,0 +1,15 @@
+import { Stack } from "aws-cdk-lib"
+import { Function } from "aws-cdk-lib/aws-lambda"
+import { RmsTables } from "../../storage/tables"
+import { defineApiFunction } from "../apiFunction"
+
+export function defineGetBatchFunction(stack: Stack, tables: RmsTables): Function {
+    return defineApiFunction(
+        stack,
+        "get-batch",
+        "GetBatch",
+        "handlers/api/GetBatch.handler",
+        tables,
+        ["main", "items", "batch"]
+    )
+}

--- a/amplify/functions/get-item/resource.ts
+++ b/amplify/functions/get-item/resource.ts
@@ -1,0 +1,15 @@
+import { Stack } from "aws-cdk-lib"
+import { Function } from "aws-cdk-lib/aws-lambda"
+import { RmsTables } from "../../storage/tables"
+import { defineApiFunction } from "../apiFunction"
+
+export function defineGetItemFunction(stack: Stack, tables: RmsTables): Function {
+    return defineApiFunction(
+        stack,
+        "get-item",
+        "GetItem",
+        "handlers/api/GetItem.handler",
+        tables,
+        ["main", "items"]
+    )
+}

--- a/amplify/functions/get-reservation/resource.ts
+++ b/amplify/functions/get-reservation/resource.ts
@@ -1,0 +1,15 @@
+import { Stack } from "aws-cdk-lib"
+import { Function } from "aws-cdk-lib/aws-lambda"
+import { RmsTables } from "../../storage/tables"
+import { defineApiFunction } from "../apiFunction"
+
+export function defineGetReservationFunction(stack: Stack, tables: RmsTables): Function {
+    return defineApiFunction(
+        stack,
+        "get-reservation",
+        "GetReservation",
+        "handlers/api/GetReservation.handler",
+        tables,
+        ["schedule"]
+    )
+}

--- a/amplify/functions/list-items/resource.ts
+++ b/amplify/functions/list-items/resource.ts
@@ -1,0 +1,15 @@
+import { Stack } from "aws-cdk-lib"
+import { Function } from "aws-cdk-lib/aws-lambda"
+import { RmsTables } from "../../storage/tables"
+import { defineApiFunction } from "../apiFunction"
+
+export function defineListItemsFunction(stack: Stack, tables: RmsTables): Function {
+    return defineApiFunction(
+        stack,
+        "list-items",
+        "ListItems",
+        "handlers/api/ListItems.handler",
+        tables,
+        ["main"]
+    )
+}

--- a/amplify/functions/list-reservations/resource.ts
+++ b/amplify/functions/list-reservations/resource.ts
@@ -1,0 +1,15 @@
+import { Stack } from "aws-cdk-lib"
+import { Function } from "aws-cdk-lib/aws-lambda"
+import { RmsTables } from "../../storage/tables"
+import { defineApiFunction } from "../apiFunction"
+
+export function defineListReservationsFunction(stack: Stack, tables: RmsTables): Function {
+    return defineApiFunction(
+        stack,
+        "list-reservations",
+        "ListReservations",
+        "handlers/api/ListReservations.handler",
+        tables,
+        ["schedule"]
+    )
+}

--- a/amplify/functions/search-item/resource.ts
+++ b/amplify/functions/search-item/resource.ts
@@ -1,0 +1,15 @@
+import { Stack } from "aws-cdk-lib"
+import { Function } from "aws-cdk-lib/aws-lambda"
+import { RmsTables } from "../../storage/tables"
+import { defineApiFunction } from "../apiFunction"
+
+export function defineSearchItemFunction(stack: Stack, tables: RmsTables): Function {
+    return defineApiFunction(
+        stack,
+        "search-item",
+        "SearchItem",
+        "handlers/api/SearchItem.handler",
+        tables,
+        ["main", "tags"]
+    )
+}

--- a/ts-code/__dev__/db/LocalDBClient.ts
+++ b/ts-code/__dev__/db/LocalDBClient.ts
@@ -182,16 +182,49 @@ export class LocalDBClient implements DBClient {
         })
     }
     
-    // Default to full table scan for now.
     public scan(params: ScanCommandInput): Promise<ScanCommandOutput> {
         return this.newPromise(() => {
-            const table: any[] = Object.values(this.getTable(params.TableName))
+            const allEntries: [string, any][] = Object.entries(this.getTable(params.TableName))
+                .sort(([a], [b]) => a.localeCompare(b))
+
+            const startAfterKey: string | undefined = params.ExclusiveStartKey
+                ? Object.values(params.ExclusiveStartKey)[0] as string
+                : undefined
+            const startIndex: number = startAfterKey
+                ? allEntries.findIndex(([key]) => key === startAfterKey) + 1
+                : 0
+
+            const scanned: [string, any][] = allEntries.slice(startIndex)
+            const limit: number = params.Limit ?? scanned.length
+            const page: [string, any][] = scanned.slice(0, limit)
+            const filtered: any[] = this.applyFilter(page.map(([, value]) => value), params)
+
+            const lastEvaluatedKey = page.length === limit && scanned.length > limit
+                ? { id: page[page.length - 1][0] }
+                : undefined
+
             return {
-                Items: table,
-                Count: table.length,
-                ScannedCount: table.length
+                Items: filtered,
+                Count: filtered.length,
+                ScannedCount: page.length,
+                ...(lastEvaluatedKey ? { LastEvaluatedKey: lastEvaluatedKey } : {})
             }
         })
+    }
+
+    private applyFilter(items: any[], params: ScanCommandInput): any[] {
+        if (!params.FilterExpression) {
+            return items
+        }
+
+        // Only supports this repo's one real usage: "#key = :val".
+        const match = params.FilterExpression.match(/^#(\w+) = :(\w+)$/)
+        if (!match) {
+            throw new Error(`Unsupported FilterExpression: ${params.FilterExpression}`)
+        }
+        const attrName: string = params.ExpressionAttributeNames[`#${match[1]}`]
+        const attrValue: any = params.ExpressionAttributeValues[`:${match[2]}`]
+        return items.filter((item: any) => item[attrName] === attrValue)
     }
 
     private getTable(tableName: string): any {

--- a/ts-code/__dev__/metrics/LocalMetricsClient.ts
+++ b/ts-code/__dev__/metrics/LocalMetricsClient.ts
@@ -19,7 +19,8 @@ export class LocalMetricsClient implements MetricsClient {
                             .then(() => response)
                     },
                     (reason: any) => {
-                        throw this.emitErrors(1)
+                        return this.emitDuration(startTime)
+                            .then(() => this.emitErrors(1))
                             .then(() => { throw reason })
                     }
                 )

--- a/ts-code/__tests__/unit/api/GetBatch.test.ts
+++ b/ts-code/__tests__/unit/api/GetBatch.test.ts
@@ -25,3 +25,29 @@ test('will override existing batch when batch already exist', async () => {
     ).rejects.toThrow(`Unable to find Batch '${TestConstants.BAD_REQUEST}'`)
     expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES_TWO_BATCH)
 })
+
+test('will get batch details enriched with name/owner/borrower when batch exists', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_TWO_BATCH)
+    const api: GetBatch = new GetBatch(dbClient)
+
+    await expect(
+        api.executeDetailed({
+            name: TestConstants.BATCH
+        })
+    ).resolves.toEqual([
+        { id: TestConstants.ITEM_ID, name: TestConstants.DISPLAYNAME, owner: TestConstants.OWNER, borrower: "" },
+        { id: TestConstants.ITEM_ID_2, name: "test name 2", owner: TestConstants.OWNER_2, borrower: "" }
+    ])
+    expect(dbClient.getDB()).toEqual(DBSeed.TWO_NAMES_TWO_BATCH)
+})
+
+test('will fail executeDetailed when batch is not found', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_TWO_BATCH)
+    const api: GetBatch = new GetBatch(dbClient)
+
+    await expect(
+        api.executeDetailed({
+            name: TestConstants.BAD_REQUEST
+        })
+    ).rejects.toThrow(`Unable to find Batch '${TestConstants.BAD_REQUEST}'`)
+})

--- a/ts-code/__tests__/unit/api/ListItems.test.ts
+++ b/ts-code/__tests__/unit/api/ListItems.test.ts
@@ -1,0 +1,60 @@
+import { ListItems, ListItemsResult } from "../../../src/api/ListItems"
+import { DBSeed, TestConstants } from "../../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../../__dev__/db/LocalDBClient"
+import { MainSchema } from "../../../src/db/Schemas"
+
+function mainEntry(id: string): MainSchema {
+    return {
+        id,
+        displayName: id,
+        description: "",
+        owner: "",
+        location: "",
+        batch: [],
+        tags: [],
+        items: []
+    }
+}
+
+const THREE_NAMES = {
+    main: {
+        "aaa": mainEntry("aaa"),
+        "bbb": mainEntry("bbb"),
+        "ccc": mainEntry("ccc")
+    },
+    items: {},
+    batch: {},
+    tags: {},
+    history: {},
+    schedule: {},
+    transactions: {}
+}
+
+test('will list no items when table is empty', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.EMPTY)
+    const api: ListItems = new ListItems(dbClient)
+
+    await expect(api.execute({})).resolves.toEqual({ items: [], nextPageToken: undefined })
+})
+
+test('will list all items in one page when limit exceeds table size', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES)
+    const api: ListItems = new ListItems(dbClient)
+
+    const result: ListItemsResult = await api.execute({})
+    expect(result.items.map((i) => i.id).sort()).toEqual([TestConstants.NAME, TestConstants.NAME_2].sort())
+    expect(result.nextPageToken).toBeUndefined()
+})
+
+test('will paginate when limit is smaller than table size, and following the token advances', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(THREE_NAMES as any)
+    const api: ListItems = new ListItems(dbClient)
+
+    const firstPage: ListItemsResult = await api.execute({ limit: 2 })
+    expect(firstPage.items.map((i) => i.id)).toEqual(["aaa", "bbb"])
+    expect(firstPage.nextPageToken).toBeDefined()
+
+    const secondPage: ListItemsResult = await api.execute({ limit: 2, pageToken: firstPage.nextPageToken })
+    expect(secondPage.items.map((i) => i.id)).toEqual(["ccc"])
+    expect(secondPage.nextPageToken).toBeUndefined()
+})

--- a/ts-code/__tests__/unit/api/ListReservations.test.ts
+++ b/ts-code/__tests__/unit/api/ListReservations.test.ts
@@ -1,0 +1,30 @@
+import { ListReservations } from "../../../src/api/ListReservations"
+import { DBSeed, TestConstants, TestTimestamps } from "../../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../../__dev__/db/LocalDBClient"
+import { ScheduleSchema } from "../../../src/db/Schemas"
+
+const RESERVED_SCHEDULE: ScheduleSchema = {
+    id: TestConstants.RESERVATION_ID,
+    borrower: TestConstants.BORROWER,
+    itemIds: [TestConstants.ITEM_ID, TestConstants.ITEM_ID_2],
+    startTime: TestTimestamps.START_DATE,
+    endTime: TestTimestamps.END_DATE,
+    notes: TestConstants.NOTES
+}
+
+test('will list reservations for a borrower when they exist', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_ONE_BATCH_RESERVED)
+    const api: ListReservations = new ListReservations(dbClient)
+
+    await expect(api.execute({ borrower: TestConstants.BORROWER })).resolves.toEqual({
+        items: [RESERVED_SCHEDULE],
+        nextPageToken: undefined
+    })
+})
+
+test('will fail when borrower is missing', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_ONE_BATCH_RESERVED)
+    const api: ListReservations = new ListReservations(dbClient)
+
+    await expect(api.execute({})).rejects.toThrow("Missing required field 'borrower'")
+})

--- a/ts-code/__tests__/unit/db/ScheduleTable.test.ts
+++ b/ts-code/__tests__/unit/db/ScheduleTable.test.ts
@@ -1,0 +1,33 @@
+import { ScheduleTable } from "../../../src/db/ScheduleTable"
+import { DBSeed, TestConstants, TestTimestamps } from "../../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../../__dev__/db/LocalDBClient"
+import { ScheduleSchema } from "../../../src/db/Schemas"
+
+const RESERVED_SCHEDULE: ScheduleSchema = {
+    id: TestConstants.RESERVATION_ID,
+    borrower: TestConstants.BORROWER,
+    itemIds: [TestConstants.ITEM_ID, TestConstants.ITEM_ID_2],
+    startTime: TestTimestamps.START_DATE,
+    endTime: TestTimestamps.END_DATE,
+    notes: TestConstants.NOTES
+}
+
+test('will list reservations for a borrower when they exist', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_ONE_BATCH_RESERVED)
+    const table: ScheduleTable = new ScheduleTable(dbClient)
+
+    await expect(table.listByBorrower(TestConstants.BORROWER)).resolves.toEqual({
+        items: [RESERVED_SCHEDULE],
+        nextPageToken: undefined
+    })
+})
+
+test('will return no reservations when borrower has none', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_ONE_BATCH_RESERVED)
+    const table: ScheduleTable = new ScheduleTable(dbClient)
+
+    await expect(table.listByBorrower(TestConstants.BORROWER_2)).resolves.toEqual({
+        items: [],
+        nextPageToken: undefined
+    })
+})

--- a/ts-code/__tests__/unit/handlers/api/GetBatch.test.ts
+++ b/ts-code/__tests__/unit/handlers/api/GetBatch.test.ts
@@ -1,0 +1,44 @@
+import getClients from "../../../../src/handlers/api/APIHelper"
+import { handler } from "../../../../src/handlers/api/GetBatch"
+import { DBSeed, TestConstants } from "../../../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../../../__dev__/db/LocalDBClient"
+import { LocalMetricsClient } from "../../../../__dev__/metrics/LocalMetricsClient"
+
+test('will get batch details correctly when using handler', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_TWO_BATCH)
+    const metricsClient: LocalMetricsClient = new LocalMetricsClient()
+
+    getClients.getDBClient = jest.fn(() => dbClient)
+    getClients.getMetricsClient = jest.fn(() => metricsClient)
+
+    await expect(
+        handler({
+            body: JSON.stringify({ name: TestConstants.BATCH })
+        } as any, null, null)
+    ).resolves.toEqual({
+        statusCode: 200,
+        body: JSON.stringify([
+            { id: TestConstants.ITEM_ID, name: TestConstants.DISPLAYNAME, owner: TestConstants.OWNER, borrower: "" },
+            { id: TestConstants.ITEM_ID_2, name: "test name 2", owner: TestConstants.OWNER_2, borrower: "" }
+        ])
+    })
+    metricsClient.assureState(0)
+})
+
+test('will fail when batch is not found using handler', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.EMPTY)
+    const metricsClient: LocalMetricsClient = new LocalMetricsClient()
+
+    getClients.getDBClient = jest.fn(() => dbClient)
+    getClients.getMetricsClient = jest.fn(() => metricsClient)
+
+    await expect(
+        handler({
+            body: JSON.stringify({ name: TestConstants.BATCH })
+        } as any, null, null)
+    ).resolves.toEqual({
+        statusCode: 400,
+        body: JSON.stringify({ error: `Unable to find Batch '${TestConstants.BATCH}'` })
+    })
+    metricsClient.assureState(1)
+})

--- a/ts-code/__tests__/unit/handlers/api/GetItem.test.ts
+++ b/ts-code/__tests__/unit/handlers/api/GetItem.test.ts
@@ -1,0 +1,63 @@
+import getClients from "../../../../src/handlers/api/APIHelper"
+import { handler } from "../../../../src/handlers/api/GetItem"
+import { DBSeed, TestConstants } from "../../../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../../../__dev__/db/LocalDBClient"
+import { LocalMetricsClient } from "../../../../__dev__/metrics/LocalMetricsClient"
+
+test('will get item correctly when using handler', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const metricsClient: LocalMetricsClient = new LocalMetricsClient()
+
+    getClients.getDBClient = jest.fn(() => dbClient)
+    getClients.getMetricsClient = jest.fn(() => metricsClient)
+
+    await expect(
+        handler({
+            body: JSON.stringify({ key: TestConstants.ITEM_ID })
+        } as any, null, null)
+    ).resolves.toEqual({
+        statusCode: 200,
+        body: JSON.stringify({
+            main: {
+                id: TestConstants.NAME,
+                displayName: TestConstants.DISPLAYNAME,
+                description: TestConstants.DESCRIPTION,
+                items: [TestConstants.ITEM_ID],
+                tags: [TestConstants.TAG],
+                owner: TestConstants.OWNER,
+                location: TestConstants.LOCATION,
+                batch: []
+            },
+            items: [{
+                id: TestConstants.ITEM_ID,
+                name: TestConstants.NAME,
+                notes: TestConstants.NOTES,
+                borrower: "",
+                history: [],
+                schedule: [],
+                friendlyName: TestConstants.ITEM_ID,
+                borrowTime: 0,
+                returnTime: 0
+            }]
+        })
+    })
+    metricsClient.assureState(0)
+})
+
+test('will fail when item is not found using handler', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.EMPTY)
+    const metricsClient: LocalMetricsClient = new LocalMetricsClient()
+
+    getClients.getDBClient = jest.fn(() => dbClient)
+    getClients.getMetricsClient = jest.fn(() => metricsClient)
+
+    await expect(
+        handler({
+            body: JSON.stringify({ key: TestConstants.BAD_REQUEST })
+        } as any, null, null)
+    ).resolves.toEqual({
+        statusCode: 400,
+        body: JSON.stringify({ error: `Couldn't find item '${TestConstants.BAD_REQUEST}'` })
+    })
+    metricsClient.assureState(1)
+})

--- a/ts-code/__tests__/unit/handlers/api/GetReservation.test.ts
+++ b/ts-code/__tests__/unit/handlers/api/GetReservation.test.ts
@@ -1,0 +1,48 @@
+import getClients from "../../../../src/handlers/api/APIHelper"
+import { handler } from "../../../../src/handlers/api/GetReservation"
+import { DBSeed, TestConstants, TestTimestamps } from "../../../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../../../__dev__/db/LocalDBClient"
+import { LocalMetricsClient } from "../../../../__dev__/metrics/LocalMetricsClient"
+
+test('will get reservation correctly when using handler', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_ONE_BATCH_RESERVED)
+    const metricsClient: LocalMetricsClient = new LocalMetricsClient()
+
+    getClients.getDBClient = jest.fn(() => dbClient)
+    getClients.getMetricsClient = jest.fn(() => metricsClient)
+
+    await expect(
+        handler({
+            body: JSON.stringify({ id: TestConstants.RESERVATION_ID })
+        } as any, null, null)
+    ).resolves.toEqual({
+        statusCode: 200,
+        body: JSON.stringify({
+            id: TestConstants.RESERVATION_ID,
+            borrower: TestConstants.BORROWER,
+            itemIds: [TestConstants.ITEM_ID, TestConstants.ITEM_ID_2],
+            startTime: TestTimestamps.START_DATE,
+            endTime: TestTimestamps.END_DATE,
+            notes: TestConstants.NOTES
+        })
+    })
+    metricsClient.assureState(0)
+})
+
+test('will fail when reservation is not found using handler', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.EMPTY)
+    const metricsClient: LocalMetricsClient = new LocalMetricsClient()
+
+    getClients.getDBClient = jest.fn(() => dbClient)
+    getClients.getMetricsClient = jest.fn(() => metricsClient)
+
+    await expect(
+        handler({
+            body: JSON.stringify({ id: TestConstants.RESERVATION_ID })
+        } as any, null, null)
+    ).resolves.toEqual({
+        statusCode: 400,
+        body: JSON.stringify({ error: `Reservation not found. id: '${TestConstants.RESERVATION_ID}' is invalid` })
+    })
+    metricsClient.assureState(1)
+})

--- a/ts-code/__tests__/unit/handlers/api/ListItems.test.ts
+++ b/ts-code/__tests__/unit/handlers/api/ListItems.test.ts
@@ -1,0 +1,33 @@
+import getClients from "../../../../src/handlers/api/APIHelper"
+import { handler } from "../../../../src/handlers/api/ListItems"
+import { DBSeed, TestConstants } from "../../../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../../../__dev__/db/LocalDBClient"
+import { LocalMetricsClient } from "../../../../__dev__/metrics/LocalMetricsClient"
+
+test('will list items correctly when using handler', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.ONE_NAME)
+    const metricsClient: LocalMetricsClient = new LocalMetricsClient()
+
+    getClients.getDBClient = jest.fn(() => dbClient)
+    getClients.getMetricsClient = jest.fn(() => metricsClient)
+
+    await expect(
+        handler({ body: JSON.stringify({}) } as any, null, null)
+    ).resolves.toEqual({
+        statusCode: 200,
+        body: JSON.stringify({
+            items: [{
+                id: TestConstants.NAME,
+                displayName: TestConstants.DISPLAYNAME,
+                description: TestConstants.DESCRIPTION,
+                items: [TestConstants.ITEM_ID],
+                tags: [TestConstants.TAG],
+                owner: TestConstants.OWNER,
+                location: TestConstants.LOCATION,
+                batch: []
+            }],
+            nextPageToken: undefined
+        })
+    })
+    metricsClient.assureState(0)
+})

--- a/ts-code/__tests__/unit/handlers/api/ListReservations.test.ts
+++ b/ts-code/__tests__/unit/handlers/api/ListReservations.test.ts
@@ -1,0 +1,52 @@
+import getClients from "../../../../src/handlers/api/APIHelper"
+import { handler } from "../../../../src/handlers/api/ListReservations"
+import { DBSeed, TestConstants, TestTimestamps } from "../../../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../../../__dev__/db/LocalDBClient"
+import { LocalMetricsClient } from "../../../../__dev__/metrics/LocalMetricsClient"
+import { ScheduleSchema } from "../../../../src/db/Schemas"
+
+const RESERVED_SCHEDULE: ScheduleSchema = {
+    id: TestConstants.RESERVATION_ID,
+    borrower: TestConstants.BORROWER,
+    itemIds: [TestConstants.ITEM_ID, TestConstants.ITEM_ID_2],
+    startTime: TestTimestamps.START_DATE,
+    endTime: TestTimestamps.END_DATE,
+    notes: TestConstants.NOTES
+}
+
+test('will list reservations correctly when using handler', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES_ONE_BATCH_RESERVED)
+    const metricsClient: LocalMetricsClient = new LocalMetricsClient()
+
+    getClients.getDBClient = jest.fn(() => dbClient)
+    getClients.getMetricsClient = jest.fn(() => metricsClient)
+
+    await expect(
+        handler({
+            body: JSON.stringify({ borrower: TestConstants.BORROWER })
+        } as any, null, null)
+    ).resolves.toEqual({
+        statusCode: 200,
+        body: JSON.stringify({
+            items: [RESERVED_SCHEDULE],
+            nextPageToken: undefined
+        })
+    })
+    metricsClient.assureState(0)
+})
+
+test('will fail when borrower is missing using handler', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.EMPTY)
+    const metricsClient: LocalMetricsClient = new LocalMetricsClient()
+
+    getClients.getDBClient = jest.fn(() => dbClient)
+    getClients.getMetricsClient = jest.fn(() => metricsClient)
+
+    await expect(
+        handler({ body: JSON.stringify({}) } as any, null, null)
+    ).resolves.toEqual({
+        statusCode: 400,
+        body: JSON.stringify({ error: "Missing required field 'borrower'" })
+    })
+    metricsClient.assureState(1)
+})

--- a/ts-code/__tests__/unit/handlers/api/SearchItem.test.ts
+++ b/ts-code/__tests__/unit/handlers/api/SearchItem.test.ts
@@ -1,0 +1,53 @@
+import getClients from "../../../../src/handlers/api/APIHelper"
+import { handler } from "../../../../src/handlers/api/SearchItem"
+import { DBSeed, TestConstants } from "../../../../__dev__/db/DBTestConstants"
+import { LocalDBClient } from "../../../../__dev__/db/LocalDBClient"
+import { LocalMetricsClient } from "../../../../__dev__/metrics/LocalMetricsClient"
+
+test('will search item by tags correctly when using handler', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.TWO_NAMES)
+    const metricsClient: LocalMetricsClient = new LocalMetricsClient()
+
+    getClients.getDBClient = jest.fn(() => dbClient)
+    getClients.getMetricsClient = jest.fn(() => metricsClient)
+
+    await expect(
+        handler({
+            body: JSON.stringify({ tags: [TestConstants.TAG_2] })
+        } as any, null, null)
+    ).resolves.toEqual({
+        statusCode: 200,
+        body: JSON.stringify({
+            map: { [TestConstants.NAME_2]: { name: TestConstants.NAME_2, occurrences: 1, relevance: 0 } },
+            entries: [{
+                id: TestConstants.NAME_2,
+                displayName: TestConstants.NAME_2,
+                description: TestConstants.DESCRIPTION_2,
+                items: [TestConstants.ITEM_ID_2],
+                tags: [TestConstants.TAG, TestConstants.TAG_2],
+                owner: TestConstants.OWNER_2,
+                location: TestConstants.LOCATION_2,
+                batch: []
+            }]
+        })
+    })
+    metricsClient.assureState(0)
+})
+
+test('will return no matches when no tags match using handler', async () => {
+    const dbClient: LocalDBClient = new LocalDBClient(DBSeed.EMPTY)
+    const metricsClient: LocalMetricsClient = new LocalMetricsClient()
+
+    getClients.getDBClient = jest.fn(() => dbClient)
+    getClients.getMetricsClient = jest.fn(() => metricsClient)
+
+    await expect(
+        handler({
+            body: JSON.stringify({ tags: [TestConstants.TAG] })
+        } as any, null, null)
+    ).resolves.toEqual({
+        statusCode: 200,
+        body: JSON.stringify({ map: {}, entries: [] })
+    })
+    metricsClient.assureState(0)
+})

--- a/ts-code/src/api/GetBatch.ts
+++ b/ts-code/src/api/GetBatch.ts
@@ -67,10 +67,41 @@ export class GetBatch {
             GetBatch.NAME, this.metrics
         )
     }
+
+    /**
+     * Same as execute(), but enriches each item ID in the batch with its
+     * display name, owner, and borrower - the structured equivalent of
+     * what router() formats into a string, for API/browse consumers that
+     * need JSON rather than human-readable text.
+     */
+    public executeDetailed(scratch: ScratchInterface): Promise<GetBatchDetailedEntry[]> {
+        return this.execute(scratch)
+            .then((ids: string[]) => {
+                return Promise.all(ids.map((id: string) => {
+                    return this.itemTable.get(id)
+                        .then((itemEntry: ItemsSchema) => {
+                            return this.mainTable.get(itemEntry.name)
+                                .then((mainEntry: MainSchema): GetBatchDetailedEntry => ({
+                                    id,
+                                    name: mainEntry.displayName,
+                                    owner: mainEntry.owner,
+                                    borrower: itemEntry.borrower
+                                }))
+                        })
+                }))
+            })
+    }
 }
 
 interface ScratchInterface {
     name?: string
+}
+
+export interface GetBatchDetailedEntry {
+    id: string,
+    name: string,
+    owner: string,
+    borrower: string
 }
 
 export function getBatchItem(id: string, name: string, owner: string, borrower: string): string {

--- a/ts-code/src/api/ListItems.ts
+++ b/ts-code/src/api/ListItems.ts
@@ -1,0 +1,54 @@
+import { MAIN_TABLE, MainSchema } from "../db/Schemas"
+import { encodePageToken, decodePageToken } from "../db/PageToken"
+import { DBClient } from "../injection/db/DBClient"
+import { MetricsClient } from "../injection/metrics/MetricsClient"
+import { emitAPIMetrics } from "../metrics/MetricsHelper"
+import { ScanCommandInput, ScanCommandOutput } from "@aws-sdk/lib-dynamodb"
+
+const DEFAULT_PAGE_SIZE = 25
+
+/**
+ * Lists every item type (unfiltered "browse everything"), paginated.
+ * Unlike SearchItem (tag-driven), this has no query - a plain Scan across
+ * MainTable, acceptable at RMS's current scale.
+ */
+export class ListItems {
+    public static NAME: string = "list items"
+
+    private readonly client: DBClient
+    private readonly metrics?: MetricsClient
+
+    public constructor(client: DBClient, metrics?: MetricsClient) {
+        this.client = client
+        this.metrics = metrics
+    }
+
+    public execute(input: ListItemsInput): Promise<ListItemsResult> {
+        return emitAPIMetrics(
+            () => {
+                const params: ScanCommandInput = {
+                    TableName: MAIN_TABLE,
+                    Limit: input.limit ?? DEFAULT_PAGE_SIZE,
+                    ...(input.pageToken ? { ExclusiveStartKey: decodePageToken(input.pageToken) } : {})
+                }
+
+                return this.client.scan(params)
+                    .then((output: ScanCommandOutput) => ({
+                        items: (output.Items ?? []) as MainSchema[],
+                        nextPageToken: output.LastEvaluatedKey ? encodePageToken(output.LastEvaluatedKey) : undefined
+                    }))
+            },
+            ListItems.NAME, this.metrics
+        )
+    }
+}
+
+export interface ListItemsInput {
+    limit?: number,
+    pageToken?: string
+}
+
+export interface ListItemsResult {
+    items: MainSchema[],
+    nextPageToken?: string
+}

--- a/ts-code/src/api/ListReservations.ts
+++ b/ts-code/src/api/ListReservations.ts
@@ -1,0 +1,45 @@
+import { ScheduleTable, ListByBorrowerResult } from "../db/ScheduleTable"
+import { DBClient } from "../injection/db/DBClient"
+import { MetricsClient } from "../injection/metrics/MetricsClient"
+import { emitAPIMetrics } from "../metrics/MetricsHelper"
+
+/**
+ * Lists reservations for a given borrower, paginated. See
+ * ScheduleTable.listByBorrower for the pagination/filter-order caveat.
+ */
+export class ListReservations {
+    public static NAME: string = "list reservations"
+
+    private readonly scheduleTable: ScheduleTable
+    private readonly metrics?: MetricsClient
+
+    public constructor(client: DBClient, metrics?: MetricsClient) {
+        this.scheduleTable = new ScheduleTable(client)
+        this.metrics = metrics
+    }
+
+    public execute(input: ListReservationsInput): Promise<ListByBorrowerResult> {
+        return emitAPIMetrics(
+            () => {
+                return this.performAllFVAs(input)
+                    .then(() => this.scheduleTable.listByBorrower(input.borrower, input.limit, input.pageToken))
+            },
+            ListReservations.NAME, this.metrics
+        )
+    }
+
+    private performAllFVAs(input: ListReservationsInput): Promise<void> {
+        return new Promise((resolve, reject) => {
+            if (input.borrower == undefined) {
+                reject(new Error("Missing required field 'borrower'"))
+            }
+            resolve()
+        })
+    }
+}
+
+export interface ListReservationsInput {
+    borrower?: string,
+    limit?: number,
+    pageToken?: string
+}

--- a/ts-code/src/api/SearchItem.ts
+++ b/ts-code/src/api/SearchItem.ts
@@ -134,5 +134,5 @@ interface TagObject {
 export function searchItemItem(main: MainSchema, occurrences: number): string {
     return `\nName: ${main.displayName}`
         + `\n  # of relevant tags: ${occurrences}`
-        + `\n  Item IDs: ${main.tags.values.toString()}`
+        + `\n  Item IDs: ${main.tags.toString()}`
 }

--- a/ts-code/src/db/PageToken.ts
+++ b/ts-code/src/db/PageToken.ts
@@ -1,0 +1,13 @@
+/**
+ * Opaque base64 encoding of a DynamoDB ExclusiveStartKey/LastEvaluatedKey,
+ * shared by every paginated Scan-based list method (ScheduleTable,
+ * MainTable) so callers pass an opaque string rather than a raw DynamoDB
+ * key shape.
+ */
+export function encodePageToken(lastEvaluatedKey: Record<string, any>): string {
+    return Buffer.from(JSON.stringify(lastEvaluatedKey)).toString("base64")
+}
+
+export function decodePageToken(pageToken: string): Record<string, any> {
+    return JSON.parse(Buffer.from(pageToken, "base64").toString("utf-8"))
+}

--- a/ts-code/src/db/ScheduleTable.ts
+++ b/ts-code/src/db/ScheduleTable.ts
@@ -1,6 +1,9 @@
 import { SCHEDULE_TABLE, ScheduleSchema, ITEMS_TABLE, ItemsSchema } from "./Schemas";
 import { DBClient } from "../injection/db/DBClient"
-import { DeleteCommandInput, GetCommandInput, GetCommandOutput, PutCommandInput, UpdateCommandInput } from "@aws-sdk/lib-dynamodb"
+import { DeleteCommandInput, GetCommandInput, GetCommandOutput, PutCommandInput, ScanCommandInput, ScanCommandOutput, UpdateCommandInput } from "@aws-sdk/lib-dynamodb"
+import { encodePageToken, decodePageToken } from "./PageToken"
+
+const DEFAULT_PAGE_SIZE = 25
 
 export class ScheduleTable {
     private readonly client: DBClient
@@ -183,6 +186,42 @@ export class ScheduleTable {
     }
 
     /**
+     * Lists reservations for a given borrower, paginated.
+     *
+     * No GSI exists on ScheduleSchema.borrower today, so this is a table
+     * Scan with a FilterExpression - acceptable at RMS's current scale
+     * since the tables aren't CDK-managed (adding a GSI is a separate,
+     * out-of-band change). DynamoDB applies FilterExpression *after*
+     * Limit, so a returned page can have fewer (even zero) matching
+     * entries despite more data remaining - callers must keep paging
+     * using nextPageToken until it's undefined, not stop on a short page.
+     */
+    public listByBorrower(
+        borrower: string,
+        limit: number = DEFAULT_PAGE_SIZE,
+        pageToken?: string
+    ): Promise<ListByBorrowerResult> {
+        const params: ScanCommandInput = {
+            TableName: SCHEDULE_TABLE,
+            Limit: limit,
+            FilterExpression: "#borrower = :borrower",
+            ExpressionAttributeNames: {
+                "#borrower": "borrower"
+            },
+            ExpressionAttributeValues: {
+                ":borrower": borrower
+            },
+            ...(pageToken ? { ExclusiveStartKey: decodePageToken(pageToken) } : {})
+        }
+
+        return this.client.scan(params)
+            .then((output: ScanCommandOutput) => ({
+                items: (output.Items ?? []) as ScheduleSchema[],
+                nextPageToken: output.LastEvaluatedKey ? encodePageToken(output.LastEvaluatedKey) : undefined
+            }))
+    }
+
+    /**
      * Validates if the given date ranges conflict
      * @param startDate1 starting date of the first time range. Given in timestamp (number) fomat
      * @param endDate1 end date of the first time range. Given in timestamp (number) fomat
@@ -198,4 +237,9 @@ export class ScheduleTable {
             const newEndTime = new Date(endDate2)
             return (newStartTime >= oldStartTime && newStartTime <= oldEndTime) || (newEndTime >= oldStartTime && newEndTime <= oldEndTime)
     }
+}
+
+export interface ListByBorrowerResult {
+    items: ScheduleSchema[],
+    nextPageToken?: string
 }

--- a/ts-code/src/handlers/api/APIHelper.ts
+++ b/ts-code/src/handlers/api/APIHelper.ts
@@ -37,11 +37,11 @@ export function apiHelper<T>(
  * wraps.
  */
 export function apiGatewayHandler<TInput, TResult>(
-    executable: (dbClient: DBClient, metricsClient: MetricsClient, input: TInput) => Promise<TResult>
+    executable: (dbClient: DBClient, metricsClient: MetricsClient, apiInput: TInput) => Promise<TResult>
 ): APIGatewayProxyHandler {
     return async (event): Promise<APIGatewayProxyResult> => {
-        const input: TInput = JSON.parse(event.body ?? "{}")
-        return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => executable(dbClient, metricsClient, input))
+        const parsedInput: TInput = JSON.parse(event.body ?? "{}")
+        return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => executable(dbClient, metricsClient, parsedInput))
             .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
             .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
     }

--- a/ts-code/src/handlers/api/APIHelper.ts
+++ b/ts-code/src/handlers/api/APIHelper.ts
@@ -1,3 +1,4 @@
+import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda"
 import { DBClient } from "../../injection/db/DBClient";
 import { DDBClient } from "../../injection/db/DDBClient";
 import { CloudWatchClient } from "../../injection/metrics/CloudWatchClient";
@@ -25,4 +26,23 @@ export function apiHelper<T>(
     executable: (dbClient: DBClient, metricsClient: MetricsClient) => Promise<T>
 ): Promise<T>{
     return executable(getClients.getDBClient(), getClients.getMetricsClient())
+}
+
+/**
+ * Shared handler shape for every API Gateway Lambda: parse the JSON body,
+ * run it through apiHelper against the given business logic call, and
+ * translate success/failure into the 200/400 JSON envelope every one of
+ * these handlers uses. Extracted since every handlers/api/*.ts file was
+ * otherwise identical apart from which business logic class/method it
+ * wraps.
+ */
+export function apiGatewayHandler<TInput, TResult>(
+    executable: (dbClient: DBClient, metricsClient: MetricsClient, input: TInput) => Promise<TResult>
+): APIGatewayProxyHandler {
+    return async (event): Promise<APIGatewayProxyResult> => {
+        const input: TInput = JSON.parse(event.body ?? "{}")
+        return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => executable(dbClient, metricsClient, input))
+            .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
+            .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
+    }
 }

--- a/ts-code/src/handlers/api/AddItem.ts
+++ b/ts-code/src/handlers/api/AddItem.ts
@@ -1,12 +1,6 @@
-import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda"
 import { AddItem, AddItemInput } from "../../api/AddItem"
-import { DBClient } from "../../injection/db/DBClient"
-import { MetricsClient } from "../../injection/metrics/MetricsClient"
-import { apiHelper } from "./APIHelper"
+import { apiGatewayHandler } from "./APIHelper"
 
-export const handler: APIGatewayProxyHandler = async (event): Promise<APIGatewayProxyResult> => {
-    const input: AddItemInput = JSON.parse(event.body ?? "{}")
-    return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => new AddItem(dbClient, metricsClient).execute(input))
-        .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
-        .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
-}
+export const handler = apiGatewayHandler((dbClient, metricsClient, input: AddItemInput) =>
+    new AddItem(dbClient, metricsClient).execute(input)
+)

--- a/ts-code/src/handlers/api/BorrowFromSchedule.ts
+++ b/ts-code/src/handlers/api/BorrowFromSchedule.ts
@@ -1,12 +1,6 @@
-import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda"
 import { BorrowFromSchedule, BorrowFromScheduleInput } from "../../api/BorrowFromSchedule"
-import { DBClient } from "../../injection/db/DBClient"
-import { MetricsClient } from "../../injection/metrics/MetricsClient"
-import { apiHelper } from "./APIHelper"
+import { apiGatewayHandler } from "./APIHelper"
 
-export const handler: APIGatewayProxyHandler = async (event): Promise<APIGatewayProxyResult> => {
-    const input: BorrowFromScheduleInput = JSON.parse(event.body ?? "{}")
-    return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => new BorrowFromSchedule(dbClient, metricsClient).execute(input))
-        .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
-        .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
-}
+export const handler = apiGatewayHandler((dbClient, metricsClient, input: BorrowFromScheduleInput) =>
+    new BorrowFromSchedule(dbClient, metricsClient).execute(input)
+)

--- a/ts-code/src/handlers/api/BorrowItem.ts
+++ b/ts-code/src/handlers/api/BorrowItem.ts
@@ -1,12 +1,6 @@
-import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda"
 import { BorrowItem, BorrowItemInput } from "../../api/BorrowItem"
-import { DBClient } from "../../injection/db/DBClient"
-import { MetricsClient } from "../../injection/metrics/MetricsClient"
-import { apiHelper } from "./APIHelper"
+import { apiGatewayHandler } from "./APIHelper"
 
-export const handler: APIGatewayProxyHandler = async (event): Promise<APIGatewayProxyResult> => {
-    const input: BorrowItemInput = JSON.parse(event.body ?? "{}")
-    return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => new BorrowItem(dbClient, metricsClient).execute(input))
-        .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
-        .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
-}
+export const handler = apiGatewayHandler((dbClient, metricsClient, input: BorrowItemInput) =>
+    new BorrowItem(dbClient, metricsClient).execute(input)
+)

--- a/ts-code/src/handlers/api/CreateBatch.ts
+++ b/ts-code/src/handlers/api/CreateBatch.ts
@@ -1,12 +1,6 @@
-import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda"
 import { CreateBatch, CreateBatchInput } from "../../api/CreateBatch"
-import { DBClient } from "../../injection/db/DBClient"
-import { MetricsClient } from "../../injection/metrics/MetricsClient"
-import { apiHelper } from "./APIHelper"
+import { apiGatewayHandler } from "./APIHelper"
 
-export const handler: APIGatewayProxyHandler = async (event): Promise<APIGatewayProxyResult> => {
-    const input: CreateBatchInput = JSON.parse(event.body ?? "{}")
-    return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => new CreateBatch(dbClient, metricsClient).execute(input))
-        .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
-        .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
-}
+export const handler = apiGatewayHandler((dbClient, metricsClient, input: CreateBatchInput) =>
+    new CreateBatch(dbClient, metricsClient).execute(input)
+)

--- a/ts-code/src/handlers/api/CreateReservation.ts
+++ b/ts-code/src/handlers/api/CreateReservation.ts
@@ -1,12 +1,6 @@
-import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda"
 import { CreateReservation, CreateReservationInput } from "../../api/CreateReservation"
-import { DBClient } from "../../injection/db/DBClient"
-import { MetricsClient } from "../../injection/metrics/MetricsClient"
-import { apiHelper } from "./APIHelper"
+import { apiGatewayHandler } from "./APIHelper"
 
-export const handler: APIGatewayProxyHandler = async (event): Promise<APIGatewayProxyResult> => {
-    const input: CreateReservationInput = JSON.parse(event.body ?? "{}")
-    return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => new CreateReservation(dbClient, metricsClient).execute(input))
-        .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
-        .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
-}
+export const handler = apiGatewayHandler((dbClient, metricsClient, input: CreateReservationInput) =>
+    new CreateReservation(dbClient, metricsClient).execute(input)
+)

--- a/ts-code/src/handlers/api/DeleteBatch.ts
+++ b/ts-code/src/handlers/api/DeleteBatch.ts
@@ -1,12 +1,6 @@
-import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda"
 import { DeleteBatch, DeleteBatchInput } from "../../api/DeleteBatch"
-import { DBClient } from "../../injection/db/DBClient"
-import { MetricsClient } from "../../injection/metrics/MetricsClient"
-import { apiHelper } from "./APIHelper"
+import { apiGatewayHandler } from "./APIHelper"
 
-export const handler: APIGatewayProxyHandler = async (event): Promise<APIGatewayProxyResult> => {
-    const input: DeleteBatchInput = JSON.parse(event.body ?? "{}")
-    return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => new DeleteBatch(dbClient, metricsClient).execute(input))
-        .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
-        .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
-}
+export const handler = apiGatewayHandler((dbClient, metricsClient, input: DeleteBatchInput) =>
+    new DeleteBatch(dbClient, metricsClient).execute(input)
+)

--- a/ts-code/src/handlers/api/DeleteItem.ts
+++ b/ts-code/src/handlers/api/DeleteItem.ts
@@ -1,12 +1,6 @@
-import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda"
 import { DeleteItem, DeleteItemInput } from "../../api/DeleteItem"
-import { DBClient } from "../../injection/db/DBClient"
-import { MetricsClient } from "../../injection/metrics/MetricsClient"
-import { apiHelper } from "./APIHelper"
+import { apiGatewayHandler } from "./APIHelper"
 
-export const handler: APIGatewayProxyHandler = async (event): Promise<APIGatewayProxyResult> => {
-    const input: DeleteItemInput = JSON.parse(event.body ?? "{}")
-    return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => new DeleteItem(dbClient, metricsClient).execute(input))
-        .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
-        .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
-}
+export const handler = apiGatewayHandler((dbClient, metricsClient, input: DeleteItemInput) =>
+    new DeleteItem(dbClient, metricsClient).execute(input)
+)

--- a/ts-code/src/handlers/api/DeleteReservation.ts
+++ b/ts-code/src/handlers/api/DeleteReservation.ts
@@ -1,12 +1,6 @@
-import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda"
 import { DeleteReservation, DeleteReservationInput } from "../../api/DeleteReservation"
-import { DBClient } from "../../injection/db/DBClient"
-import { MetricsClient } from "../../injection/metrics/MetricsClient"
-import { apiHelper } from "./APIHelper"
+import { apiGatewayHandler } from "./APIHelper"
 
-export const handler: APIGatewayProxyHandler = async (event): Promise<APIGatewayProxyResult> => {
-    const input: DeleteReservationInput = JSON.parse(event.body ?? "{}")
-    return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => new DeleteReservation(dbClient, metricsClient).execute(input))
-        .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
-        .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
-}
+export const handler = apiGatewayHandler((dbClient, metricsClient, input: DeleteReservationInput) =>
+    new DeleteReservation(dbClient, metricsClient).execute(input)
+)

--- a/ts-code/src/handlers/api/GetBatch.ts
+++ b/ts-code/src/handlers/api/GetBatch.ts
@@ -1,0 +1,12 @@
+import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda"
+import { GetBatch } from "../../api/GetBatch"
+import { DBClient } from "../../injection/db/DBClient"
+import { MetricsClient } from "../../injection/metrics/MetricsClient"
+import { apiHelper } from "./APIHelper"
+
+export const handler: APIGatewayProxyHandler = async (event): Promise<APIGatewayProxyResult> => {
+    const input = JSON.parse(event.body ?? "{}")
+    return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => new GetBatch(dbClient, metricsClient).executeDetailed(input))
+        .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
+        .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
+}

--- a/ts-code/src/handlers/api/GetBatch.ts
+++ b/ts-code/src/handlers/api/GetBatch.ts
@@ -1,12 +1,6 @@
-import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda"
 import { GetBatch } from "../../api/GetBatch"
-import { DBClient } from "../../injection/db/DBClient"
-import { MetricsClient } from "../../injection/metrics/MetricsClient"
-import { apiHelper } from "./APIHelper"
+import { apiGatewayHandler } from "./APIHelper"
 
-export const handler: APIGatewayProxyHandler = async (event): Promise<APIGatewayProxyResult> => {
-    const input = JSON.parse(event.body ?? "{}")
-    return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => new GetBatch(dbClient, metricsClient).executeDetailed(input))
-        .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
-        .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
-}
+export const handler = apiGatewayHandler((dbClient, metricsClient, input) =>
+    new GetBatch(dbClient, metricsClient).executeDetailed(input)
+)

--- a/ts-code/src/handlers/api/GetItem.ts
+++ b/ts-code/src/handlers/api/GetItem.ts
@@ -1,12 +1,6 @@
-import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda"
 import { GetItem } from "../../api/GetItem"
-import { DBClient } from "../../injection/db/DBClient"
-import { MetricsClient } from "../../injection/metrics/MetricsClient"
-import { apiHelper } from "./APIHelper"
+import { apiGatewayHandler } from "./APIHelper"
 
-export const handler: APIGatewayProxyHandler = async (event): Promise<APIGatewayProxyResult> => {
-    const input = JSON.parse(event.body ?? "{}")
-    return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => new GetItem(dbClient, metricsClient).execute(input))
-        .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
-        .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
-}
+export const handler = apiGatewayHandler((dbClient, metricsClient, input) =>
+    new GetItem(dbClient, metricsClient).execute(input)
+)

--- a/ts-code/src/handlers/api/GetItem.ts
+++ b/ts-code/src/handlers/api/GetItem.ts
@@ -1,0 +1,12 @@
+import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda"
+import { GetItem } from "../../api/GetItem"
+import { DBClient } from "../../injection/db/DBClient"
+import { MetricsClient } from "../../injection/metrics/MetricsClient"
+import { apiHelper } from "./APIHelper"
+
+export const handler: APIGatewayProxyHandler = async (event): Promise<APIGatewayProxyResult> => {
+    const input = JSON.parse(event.body ?? "{}")
+    return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => new GetItem(dbClient, metricsClient).execute(input))
+        .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
+        .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
+}

--- a/ts-code/src/handlers/api/GetReservation.ts
+++ b/ts-code/src/handlers/api/GetReservation.ts
@@ -1,0 +1,12 @@
+import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda"
+import { GetReservation } from "../../api/GetReservation"
+import { DBClient } from "../../injection/db/DBClient"
+import { MetricsClient } from "../../injection/metrics/MetricsClient"
+import { apiHelper } from "./APIHelper"
+
+export const handler: APIGatewayProxyHandler = async (event): Promise<APIGatewayProxyResult> => {
+    const input = JSON.parse(event.body ?? "{}")
+    return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => new GetReservation(dbClient, metricsClient).execute(input))
+        .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
+        .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
+}

--- a/ts-code/src/handlers/api/GetReservation.ts
+++ b/ts-code/src/handlers/api/GetReservation.ts
@@ -1,12 +1,6 @@
-import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda"
 import { GetReservation } from "../../api/GetReservation"
-import { DBClient } from "../../injection/db/DBClient"
-import { MetricsClient } from "../../injection/metrics/MetricsClient"
-import { apiHelper } from "./APIHelper"
+import { apiGatewayHandler } from "./APIHelper"
 
-export const handler: APIGatewayProxyHandler = async (event): Promise<APIGatewayProxyResult> => {
-    const input = JSON.parse(event.body ?? "{}")
-    return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => new GetReservation(dbClient, metricsClient).execute(input))
-        .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
-        .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
-}
+export const handler = apiGatewayHandler((dbClient, metricsClient, input) =>
+    new GetReservation(dbClient, metricsClient).execute(input)
+)

--- a/ts-code/src/handlers/api/ListItems.ts
+++ b/ts-code/src/handlers/api/ListItems.ts
@@ -1,0 +1,12 @@
+import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda"
+import { ListItems } from "../../api/ListItems"
+import { DBClient } from "../../injection/db/DBClient"
+import { MetricsClient } from "../../injection/metrics/MetricsClient"
+import { apiHelper } from "./APIHelper"
+
+export const handler: APIGatewayProxyHandler = async (event): Promise<APIGatewayProxyResult> => {
+    const input = JSON.parse(event.body ?? "{}")
+    return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => new ListItems(dbClient, metricsClient).execute(input))
+        .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
+        .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
+}

--- a/ts-code/src/handlers/api/ListItems.ts
+++ b/ts-code/src/handlers/api/ListItems.ts
@@ -1,12 +1,6 @@
-import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda"
-import { ListItems } from "../../api/ListItems"
-import { DBClient } from "../../injection/db/DBClient"
-import { MetricsClient } from "../../injection/metrics/MetricsClient"
-import { apiHelper } from "./APIHelper"
+import { ListItems, ListItemsInput } from "../../api/ListItems"
+import { apiGatewayHandler } from "./APIHelper"
 
-export const handler: APIGatewayProxyHandler = async (event): Promise<APIGatewayProxyResult> => {
-    const input = JSON.parse(event.body ?? "{}")
-    return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => new ListItems(dbClient, metricsClient).execute(input))
-        .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
-        .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
-}
+export const handler = apiGatewayHandler((dbClient, metricsClient, input: ListItemsInput) =>
+    new ListItems(dbClient, metricsClient).execute(input)
+)

--- a/ts-code/src/handlers/api/ListReservations.ts
+++ b/ts-code/src/handlers/api/ListReservations.ts
@@ -1,12 +1,6 @@
-import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda"
-import { ListReservations } from "../../api/ListReservations"
-import { DBClient } from "../../injection/db/DBClient"
-import { MetricsClient } from "../../injection/metrics/MetricsClient"
-import { apiHelper } from "./APIHelper"
+import { ListReservations, ListReservationsInput } from "../../api/ListReservations"
+import { apiGatewayHandler } from "./APIHelper"
 
-export const handler: APIGatewayProxyHandler = async (event): Promise<APIGatewayProxyResult> => {
-    const input = JSON.parse(event.body ?? "{}")
-    return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => new ListReservations(dbClient, metricsClient).execute(input))
-        .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
-        .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
-}
+export const handler = apiGatewayHandler((dbClient, metricsClient, input: ListReservationsInput) =>
+    new ListReservations(dbClient, metricsClient).execute(input)
+)

--- a/ts-code/src/handlers/api/ListReservations.ts
+++ b/ts-code/src/handlers/api/ListReservations.ts
@@ -1,0 +1,12 @@
+import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda"
+import { ListReservations } from "../../api/ListReservations"
+import { DBClient } from "../../injection/db/DBClient"
+import { MetricsClient } from "../../injection/metrics/MetricsClient"
+import { apiHelper } from "./APIHelper"
+
+export const handler: APIGatewayProxyHandler = async (event): Promise<APIGatewayProxyResult> => {
+    const input = JSON.parse(event.body ?? "{}")
+    return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => new ListReservations(dbClient, metricsClient).execute(input))
+        .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
+        .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
+}

--- a/ts-code/src/handlers/api/ReturnItem.ts
+++ b/ts-code/src/handlers/api/ReturnItem.ts
@@ -1,12 +1,6 @@
-import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda"
 import { ReturnItem, ReturnItemInput } from "../../api/ReturnItem"
-import { DBClient } from "../../injection/db/DBClient"
-import { MetricsClient } from "../../injection/metrics/MetricsClient"
-import { apiHelper } from "./APIHelper"
+import { apiGatewayHandler } from "./APIHelper"
 
-export const handler: APIGatewayProxyHandler = async (event): Promise<APIGatewayProxyResult> => {
-    const input: ReturnItemInput = JSON.parse(event.body ?? "{}")
-    return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => new ReturnItem(dbClient, metricsClient).execute(input))
-        .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
-        .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
-}
+export const handler = apiGatewayHandler((dbClient, metricsClient, input: ReturnItemInput) =>
+    new ReturnItem(dbClient, metricsClient).execute(input)
+)

--- a/ts-code/src/handlers/api/SearchItem.ts
+++ b/ts-code/src/handlers/api/SearchItem.ts
@@ -1,0 +1,12 @@
+import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda"
+import { SearchItem } from "../../api/SearchItem"
+import { DBClient } from "../../injection/db/DBClient"
+import { MetricsClient } from "../../injection/metrics/MetricsClient"
+import { apiHelper } from "./APIHelper"
+
+export const handler: APIGatewayProxyHandler = async (event): Promise<APIGatewayProxyResult> => {
+    const input = JSON.parse(event.body ?? "{}")
+    return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => new SearchItem(dbClient, metricsClient).execute(input))
+        .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
+        .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
+}

--- a/ts-code/src/handlers/api/SearchItem.ts
+++ b/ts-code/src/handlers/api/SearchItem.ts
@@ -1,12 +1,6 @@
-import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda"
 import { SearchItem } from "../../api/SearchItem"
-import { DBClient } from "../../injection/db/DBClient"
-import { MetricsClient } from "../../injection/metrics/MetricsClient"
-import { apiHelper } from "./APIHelper"
+import { apiGatewayHandler } from "./APIHelper"
 
-export const handler: APIGatewayProxyHandler = async (event): Promise<APIGatewayProxyResult> => {
-    const input = JSON.parse(event.body ?? "{}")
-    return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => new SearchItem(dbClient, metricsClient).execute(input))
-        .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
-        .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
-}
+export const handler = apiGatewayHandler((dbClient, metricsClient, input) =>
+    new SearchItem(dbClient, metricsClient).execute(input)
+)

--- a/ts-code/src/handlers/api/UpdateTags.ts
+++ b/ts-code/src/handlers/api/UpdateTags.ts
@@ -1,12 +1,6 @@
-import { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda"
 import { UpdateTags, UpdateTagsInput } from "../../api/UpdateTags"
-import { DBClient } from "../../injection/db/DBClient"
-import { MetricsClient } from "../../injection/metrics/MetricsClient"
-import { apiHelper } from "./APIHelper"
+import { apiGatewayHandler } from "./APIHelper"
 
-export const handler: APIGatewayProxyHandler = async (event): Promise<APIGatewayProxyResult> => {
-    const input: UpdateTagsInput = JSON.parse(event.body ?? "{}")
-    return apiHelper((dbClient: DBClient, metricsClient: MetricsClient) => new UpdateTags(dbClient, metricsClient).execute(input))
-        .then((result) => ({ statusCode: 200, body: JSON.stringify(result) }))
-        .catch((error: Error) => ({ statusCode: 400, body: JSON.stringify({ error: error.message }) }))
-}
+export const handler = apiGatewayHandler((dbClient, metricsClient, input: UpdateTagsInput) =>
+    new UpdateTags(dbClient, metricsClient).execute(input)
+)


### PR DESCRIPTION
## Summary

First of 4 sequential PRs implementing #306 (Next.js web frontend). This PR closes a gap identified during planning: the API Gateway from #304 only exposed 10 write-style POST routes (`add-item`, `borrow-item`, etc.) — there was no way to read/list data at all, which blocks a browsable frontend entirely.

Adds 6 new POST routes, all Cognito-authorized like the existing 10, following the exact same handler pattern:

- `get-item`, `search-item`, `get-reservation` — thin wrappers around existing `GetItem`/`SearchItem`/`GetReservation` business logic (unchanged return shapes).
- `get-batch` — new `GetBatch.executeDetailed()` method (item ID enriched with name/owner/borrower), since `execute()` only returned bare item IDs. Confirmed non-breaking: the SMS router calls `.router()`, never `.execute()` directly.
- `list-items` — new `ListItems` class, paginated Scan over `MainTable` (no prior "browse everything" capability existed).
- `list-reservations` — new `ListReservations` class + `ScheduleTable.listByBorrower()`, paginated Scan+filter (no GSI exists on `borrower` yet; acceptable at current scale since tables aren't CDK-managed).

Pagination (`limit`/`pageToken` in, `nextPageToken` out, opaque base64-encoded DynamoDB key) is shared via a new `ts-code/src/db/PageToken.ts` helper, used by both new list endpoints.

Also added a `CfnOutput` for the API Gateway's invoke URL in `amplify/api/resource.ts` — `ampx generate outputs` doesn't surface a custom `RestApi`'s URL on its own, and the frontend will need it to discover the API endpoint.

## Incidental fixes

Writing real test coverage for these new read paths surfaced two pre-existing, previously-untested bugs:
- `SearchItem.ts`: `main.tags.values.toString()` → `main.tags.toString()` (`tags` is `string[]`, `.values` isn't a valid property — never hit because `SearchItem` had no HTTP route until now).
- `ts-code/__dev__/metrics/LocalMetricsClient.ts` (test fixture, not production code): the error-path branch of `emitPromiseMetrics` threw a Promise instead of returning it (crashing the Node process on any test combining a real error path with `LocalMetricsClient`), and never recorded a duration on failure. No prior test combined an error-path assertion with `assureState()`, so this was never exercised until this PR's new negative-path tests.

## Test plan

- [x] `npm run build` — compiles clean
- [x] `npm run test:unit` — 41 suites / 131 tests passing, coverage 92%/84%/92%/92% (well above the 80% floor)
- [x] `npx tsc --noEmit -p amplify/tsconfig.json` — typechecks clean
- [ ] CI green (`backend-ci.yml`)
- [ ] Merge, then verify via `backend-cd.yml`'s post-merge `alpha` deploy + `npm run test:integ` (per repo's deploy-verification policy) before considering this PR done

Refs #306