### PR TITLE
GH-306 (PR 1 hotfix): Fix backend-build-gen2.js missing new function names

### DIFF
--- a/backend-build-gen2.js
+++ b/backend-build-gen2.js
@@ -31,7 +31,13 @@ const API_NAMES = [
                     "DeleteItem",
                     "DeleteReservation",
                     "ReturnItem",
-                    "UpdateTags"
+                    "UpdateTags",
+                    "GetItem",
+                    "SearchItem",
+                    "GetReservation",
+                    "GetBatch",
+                    "ListItems",
+                    "ListReservations"
 ]
 
 function kebabCase(name) {


### PR DESCRIPTION
## Summary

Post-merge hotfix for #311 (PR 1/4 of #306). That PR wired 6 new Lambda functions (`GetItem`, `SearchItem`, `GetReservation`, `GetBatch`, `ListItems`, `ListReservations`) into `amplify/backend.ts` and `amplify/api/resource.ts`, but I forgot to add their names to `backend-build-gen2.js`'s `API_NAMES` list — the list that actually drives which functions get their `build/` directory populated by the compile step.

This broke the post-merge `alpha` deploy: CDK failed with `[CannotFindAsset] Cannot find asset at .../amplify/functions/get-item/build` (and would have failed identically for the other 5) since `npm run build:gen2` never wrote anything there.

## Fix

Added the 6 missing names to `API_NAMES` in `backend-build-gen2.js`. Verified locally: `npm run build:gen2` now produces a correctly populated `build/` directory (handler, api class, db/injection/metrics deps) for all 6 new functions, matching what their `resource.ts` files expect via `Code.fromAsset(...)`.

## Test plan

- [x] `npm run build` — compiles clean
- [x] `npm run build:gen2` — confirmed all 6 new functions' `build/` directories are populated correctly
- [x] `npm run test:unit` — 41 suites / 131 tests passing, coverage unaffected
- [ ] CI green
- [ ] Merge, then verify via `backend-cd.yml`'s post-merge `alpha` deploy + `npm run test:integ` actually succeeds this time

Refs #306