### PR TITLE
Connect Amplify Hosting to a real alpha Git branch, mirrored from master

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -51,6 +51,13 @@ jobs:
         run: |
           npm run test:integ
 
+      - name: fast-forward alpha branch
+        # Amplify Hosting (web/) is connected to the "alpha" Git branch, kept
+        # as a pure mirror of master -- only advanced here, after a successful
+        # backend deploy + integ test, so Hosting never builds against a
+        # backend that failed verification.
+        run: git push origin HEAD:refs/heads/alpha
+
       - name: Report Status
         uses: ravsamhq/notify-slack-action@v2
         if: always()

--- a/amplify.yml
+++ b/amplify.yml
@@ -6,7 +6,7 @@ applications:
         preBuild:
           commands:
             - npm ci
-            - npx ampx generate outputs --app-id $AWS_APP_ID --branch alpha --out-dir .
+            - npx ampx generate outputs --app-id $AWS_APP_ID --branch $AWS_BRANCH --out-dir .
         build:
           commands:
             - npm run build
@@ -23,13 +23,11 @@ applications:
           commands:
             # web/ has no CDK backend of its own; ts-code's Gen 2 backend
             # is deployed independently by .github/workflows/backend-cd.yml
-            # against the "alpha" environment (an Amplify/CDK environment
-            # name, decoupled from Git branches -- there's no Git branch
-            # literally named "alpha"). Hosting's connected Git branch is
-            # "master", so --branch is hardcoded to "alpha" here rather
-            # than $AWS_BRANCH. Substituting `ampx generate outputs` for
-            # the default `ampx pipeline-deploy` is the documented way to
-            # skip Amplify Hosting's own backend deploy while still
-            # fetching config for the frontend build (there's no dedicated
-            # Gen 2 "skip backend build" flag -- that's Gen-1-only).
-            - npx ampx generate outputs --app-id $AWS_APP_ID --branch alpha --out-dir ../web
+            # (triggered on push to master, then fast-forwarded onto the
+            # "alpha" Git branch that Hosting is connected to -- see that
+            # workflow). Substituting `ampx generate outputs` for the
+            # default `ampx pipeline-deploy` is the documented way to skip
+            # Amplify Hosting's own backend deploy while still fetching
+            # config for the frontend build (there's no dedicated Gen 2
+            # "skip backend build" flag -- that's Gen-1-only).
+            - npx ampx generate outputs --app-id $AWS_APP_ID --branch $AWS_BRANCH --out-dir ../web


### PR DESCRIPTION
## Summary
- Amplify Hosting's Console requires connecting to a real Git branch, but `alpha` has only ever existed as a CDK/`ampx` environment name (used via `ampx pipeline-deploy --branch alpha` / `ampx generate outputs --branch alpha`), not an actual Git branch — confirmed via `git ls-remote --heads origin` showing no `alpha` branch.
- Created a real `alpha` Git branch (currently identical to `master`) for Amplify Hosting to connect to and build `web/` from.
- `backend-cd.yml` now fast-forwards `alpha` to `master`'s HEAD, but only *after* a successful backend deploy + `test:integ` — so Hosting never builds a frontend against a backend that failed verification.
- `amplify.yml`'s two `ampx generate outputs --branch alpha` calls now use `--branch $AWS_BRANCH` instead, since the Git branch name and CDK environment name are now the same string.
- `backend-cd.yml`'s own trigger (push to `master`, `paths: amplify/**`) and its `ampx pipeline-deploy --branch alpha` deploy target are both unchanged — `alpha` there is still the CDK environment name, decoupled from the fast-forward mechanism added here.

This intentionally does **not** touch `backend-cd.yml`'s push trigger or the multi-tenant (per-city branch) rollout — that's separately scoped future work per `#306`'s plan.

## Test plan
- [x] Reviewed diff locally; no `ts-code`/`amplify` CDK logic changed, so no new unit test is needed (CI-workflow-only change, consistent with prior small CI fixes in this repo).
- [ ] CI green on this PR.
- [ ] After merge: confirm the next `backend-cd.yml` run's new "fast-forward alpha branch" step succeeds and `alpha` actually advances (`git ls-remote --heads origin alpha` matches `master`).
- [ ] Confirm Amplify Hosting's Console connection to the `alpha` branch (separate manual step, in progress) builds successfully once this merges.
