### PR TITLE
Make alpha the PR merge target; add manual alpha->beta->master promotion

### DIFF
--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -157,13 +157,15 @@ earlier in this same session — reuse that result).
    - If a branch matching this pattern already exists (e.g. from a prior
      partial attempt), **ask the user** whether to resume that branch or
      create a new `vN` — don't silently pick one.
-   - **Always branch from `origin/master`, never from whatever branch
-     happens to be checked out** — this repo's default branch is `master`,
-     not `main`. A prior session may have left an unrelated issue's branch
-     active, and branching from that silently drags its commits into the
-     new branch's history. Run `git fetch origin master` first, then
-     create and switch to the new branch from the fetched ref:
-     `git checkout -b GH-<N>/<username>/v<n> origin/master`.
+   - **Always branch from `origin/alpha`, never from whatever branch
+     happens to be checked out** — this repo's default branch is `alpha`,
+     not `main` or `master` (see root CLAUDE.md's "Branching and
+     environment promotion" section). A prior session may have left an
+     unrelated issue's branch active, and branching from that silently
+     drags its commits into the new branch's history. Run
+     `git fetch origin alpha` first, then create and switch to the new
+     branch from the fetched ref:
+     `git checkout -b GH-<N>/<username>/v<n> origin/alpha`.
 
 9. **Implement per the approved plan**, following this repo's existing
    conventions — most importantly the standing testing policy in root
@@ -179,7 +181,7 @@ earlier in this same session — reuse that result).
    auto-close the issue; the user closes it manually after testing.
 
 10. **Pushing/merging**: `.github/workflows/backend-ci.yml` runs build +
-    unit tests + an 80% coverage gate on every PR to `master` — open a PR
+    unit tests + an 80% coverage gate on every PR to `alpha` — open a PR
     with `gh pr create` and wait for that check to go green before merging,
-    rather than pushing directly to `master`. Ask before pushing/merging,
+    rather than pushing directly to `alpha`. Ask before pushing/merging,
     same as normal.

--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -3,9 +3,13 @@ name: Backend CD
 
 # Controls when the action will run.
 on:
-  # Triggers the workflow on push events but only for the master branch
+  # Triggers the workflow on push events but only for the alpha branch --
+  # alpha is this repo's active-development merge target and has the only
+  # provisioned backend environment today (see root CLAUDE.md's
+  # "Branching and environment promotion" section). beta/production get
+  # their own deploy workflows once those environments are provisioned.
   push:
-    branches: [ master ]
+    branches: [ alpha ]
     paths: [ 'amplify/**' ]
 
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -3,9 +3,11 @@ name: Backend CI
 
 # Controls when the action will run.
 on:
-  # Triggers the workflow on pull request events but only for the master branch
+  # Triggers the workflow on pull request events but only for the alpha branch
+  # (alpha is this repo's active-development merge target -- see the
+  # "Branching and environment promotion" section in root CLAUDE.md)
   pull_request:
-    branches: [ master ]
+    branches: [ alpha ]
 
 jobs:
   run-unit-test:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -3,7 +3,7 @@ name: Frontend CI
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ alpha ]
     paths: [ 'web/**' ]
 
 jobs:

--- a/.github/workflows/issue-branch-merged.yml
+++ b/.github/workflows/issue-branch-merged.yml
@@ -2,7 +2,7 @@ name: Mark issue ready for testing on merge
 
 on:
   push:
-    branches: [master]
+    branches: [alpha]
 
 permissions:
   contents: read
@@ -62,5 +62,5 @@ jobs:
         run: |
           set -euo pipefail
           gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body \
-            "Merged to \`master\` at ${MERGE_SHA} — ready for testing. This issue stays open until manually verified and closed."
+            "Merged to \`alpha\` at ${MERGE_SHA} — ready for testing. This issue stays open until manually verified and closed."
           gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "ready-for-testing"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,69 @@
+# Manually promote code from one environment branch to the next, per this
+# repo's alpha -> beta -> master branching model (see root CLAUDE.md's
+# "Branching and environment promotion" section). Deliberately a manual
+# workflow_dispatch, not an automatic push trigger -- promotion is a
+# deliberate "this is verified, ship it further" decision, not something
+# that should fire on every merge to alpha.
+#
+# This workflow only moves code (fast-forwards the target branch to the
+# source branch's HEAD). It does not deploy anything itself -- pushing to
+# the target branch is what triggers that branch's own CD workflow (e.g.
+# backend-cd.yml for alpha). beta and production don't have CD workflows
+# yet, since neither environment is provisioned -- see the guard below.
+name: Promote environment branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Environment to promote into"
+        required: true
+        type: choice
+        options:
+          - beta
+          - master
+
+permissions:
+  contents: write
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Guard against promoting to an unprovisioned environment
+        if: github.event.inputs.target == 'beta'
+        run: |
+          echo "::error::The beta environment isn't provisioned yet (no Amplify app, tables, etc). Nothing to promote into -- see root CLAUDE.md's 'Branching and environment promotion' section for what's needed before this target can be used."
+          exit 1
+
+      - name: Determine source branch for this target
+        id: source
+        run: |
+          case "${{ github.event.inputs.target }}" in
+            beta) echo "branch=alpha" >> "$GITHUB_OUTPUT" ;;
+            master) echo "branch=alpha" >> "$GITHUB_OUTPUT" ;;
+          esac
+          # master promotes directly from alpha for now, since beta has no
+          # environment to verify against yet. Once beta is provisioned,
+          # change master's source to beta here so promotion always goes
+          # through the full alpha -> beta -> master chain.
+
+      - name: Fast-forward target branch
+        env:
+          SOURCE_BRANCH: ${{ steps.source.outputs.branch }}
+          TARGET_BRANCH: ${{ github.event.inputs.target }}
+        run: |
+          set -euo pipefail
+          git fetch origin "$SOURCE_BRANCH" "$TARGET_BRANCH"
+
+          if ! git merge-base --is-ancestor "origin/$TARGET_BRANCH" "origin/$SOURCE_BRANCH"; then
+            echo "::error::origin/$TARGET_BRANCH has commits not present on origin/$SOURCE_BRANCH -- this isn't a fast-forward. Resolve manually (merge or rebase) before promoting."
+            exit 1
+          fi
+
+          git push origin "origin/$SOURCE_BRANCH:refs/heads/$TARGET_BRANCH"
+          echo "Promoted $SOURCE_BRANCH -> $TARGET_BRANCH ($(git rev-parse --short origin/$SOURCE_BRANCH))"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 RMS ("Reservation Management System") tracks borrowable/reservable items: item inventory, borrow/return, batches of items, and scheduled reservations. There's also an SMS-based interface (`smsrouter`) for interacting via text.
 
+## Branching and environment promotion (standing rule)
+
+**`alpha` is this repo's default branch and the merge target for all PRs** — not `master`. Every backend/frontend CI workflow (`backend-ci.yml`, `frontend-ci.yml`) gates PRs against `alpha`, and `backend-cd.yml` deploys on push to `alpha`. The issue pipeline (below) branches from `origin/alpha`, not `origin/master`.
+
+The intended long-term model is a promotion chain: **`alpha` → `beta` → `master`**, where each stage is a real deployed environment (own Amplify Hosting branch, own backend deploy). `master` is the **production** branch — the promotion *destination*, not the source of truth for active development. Each stage is meant to eventually fan out to multiple per-city branches (e.g. `beta`'s and `master`'s work will expand into one branch per church/city once the multi-tenant rollout — tracked separately, see the "Not in scope" note on the frontend epic — is built out); for now, only `alpha` exists as a real environment.
+
+**Today, only `alpha` is provisioned** (the Amplify app, Cognito pool, DynamoDB tables, etc. described below). `beta` and `master`/production have no infrastructure yet — don't treat `master` as deployable until that's built.
+
+**Promotion between stages is a manual, deliberate action, not automatic.** Run the **"Promote environment branch"** workflow (`.github/workflows/promote.yml`, triggered via `workflow_dispatch` — GitHub Actions tab, or `gh workflow run promote.yml -f target=master`) once you've verified a change in `alpha` and are ready to ship it further. It fast-forwards the target branch (`beta` or `master`) to the source branch's current HEAD (`alpha`, or eventually `beta` once that stage exists) — it does not itself deploy anything; pushing to the target branch is what triggers that branch's own CD workflow. Attempting to promote to `beta` today fails fast with a clear error, since there's no `beta` environment yet to promote into. When `beta` is provisioned, update `promote.yml`'s source-branch mapping so `master` promotes from `beta` instead of directly from `alpha`, keeping the full chain intact.
+
 ## Testing policy (standing rule)
 
 **Every change to this repo must include a corresponding test change.** A PR that alters backend or frontend behavior without adding or updating a test is incomplete, not just "missing polish" — treat it the same as a PR that doesn't compile.
@@ -76,8 +86,9 @@ amplify/
 
 ### CI/CD
 
-- `.github/workflows/backend-ci.yml` — PRs to `master`: build + `test:unit`, 80% coverage gate, plus a `tsc --noEmit -p amplify/tsconfig.json` typecheck step for the CDK code.
-- `.github/workflows/backend-cd.yml` — push to `master` touching `amplify/**`: `npx ampx pipeline-deploy --branch alpha --app-id ...` to deploy, then `test:integ`.
+- `.github/workflows/backend-ci.yml` — PRs to `alpha`: build + `test:unit`, 80% coverage gate, plus a `tsc --noEmit -p amplify/tsconfig.json` typecheck step for the CDK code.
+- `.github/workflows/backend-cd.yml` — push to `alpha` touching `amplify/**`: `npx ampx pipeline-deploy --branch alpha --app-id ...` to deploy, then `test:integ`.
+- `.github/workflows/promote.yml` — manual promotion to `beta`/`master`, see "Branching and environment promotion" above.
 - `.github/workflows/backend-canary.yml` — hourly smoke test against the deployed `alpha` env.
 
 None of these currently touch a frontend — there is no frontend build/deploy step yet.
@@ -102,13 +113,14 @@ that's what gets the work tracked as an issue and kept in sync as the plan
 iterates. Work that won't produce a code change (answering a question,
 explaining existing behavior) skips the pipeline entirely.
 
-**Always branch from `origin/master`, never from whatever branch happens
-to be checked out.** This repo's default branch is `master`, not `main` —
-double-check before scripting anything that assumes otherwise. A prior
-session may have left an unrelated issue's branch checked out; branching
-from that instead of `master` silently drags its commits into the new
-branch's history. Always `git fetch origin master` first, then
-`git checkout -b <new-branch> origin/master`.
+**Always branch from `origin/alpha`, never from whatever branch happens
+to be checked out.** This repo's default branch is `alpha`, not `main` or
+`master` — double-check before scripting anything that assumes otherwise
+(see "Branching and environment promotion" above). A prior session may
+have left an unrelated issue's branch checked out; branching from that
+instead of `alpha` silently drags its commits into the new branch's
+history. Always `git fetch origin alpha` first, then
+`git checkout -b <new-branch> origin/alpha`.
 
 - **`/issue-create <text>`** — turns a raw chunk of text (notes, a plan
   draft, a bug description) into a GitHub issue. First checks open issues
@@ -153,13 +165,13 @@ branch's history. Always `git fetch origin master` first, then
   labels only, without fetching the comment thread — for the full
   triage/plan history use `/issue-triage <N>` instead.
 - **`.github/workflows/issue-branch-merged.yml`** — triggers on push to
-  `master`, no Claude/API involved (pure shell + `gh`). Detects a
+  `alpha`, no Claude/API involved (pure shell + `gh`). Detects a
   just-merged `GH-<N>/...` branch by name, comments "ready for testing" on
   issue `N`, and applies the `ready-for-testing` label. It does **not**
   close the issue — the user verifies manually and closes it themselves.
 
 `.github/workflows/backend-ci.yml` already runs build + `test:unit` + an
-80% coverage gate on every PR to `master` — PR + green CI before merging is
+80% coverage gate on every PR to `alpha` — PR + green CI before merging is
 this repo's convention for issue-pipeline branches (`/issue-triage`'s
 "Pushing/merging" step), same as it is for any other PR.
 
@@ -176,8 +188,8 @@ returns the highest number across *both* issues and PRs — GitHub's
 as long as nothing else creates an issue/PR in the gap between checking and
 creating (a real but narrow race — if it happens, just redo the
 rename/PR once more against the actual number). **Always branch from
-`origin/master`** (`git fetch origin master` then `git checkout -b ...
-origin/master`), never from whatever branch happens to be checked out —
+`origin/alpha`** (`git fetch origin alpha` then `git checkout -b ...
+origin/alpha`), never from whatever branch happens to be checked out —
 see the callout above. Name and push the branch as
 `GH-<predicted-number>/<github-username>/v1` **first**, then run
 `gh pr create` from it, and confirm the returned PR number matches.

--- a/amplify.yml
+++ b/amplify.yml
@@ -6,7 +6,7 @@ applications:
         preBuild:
           commands:
             - npm ci
-            - npx ampx generate outputs --app-id $AWS_APP_ID --branch alpha --out-dir .
+            - npx ampx generate outputs --app-id $AWS_APP_ID --branch $AWS_BRANCH --out-dir .
         build:
           commands:
             - npm run build
@@ -21,15 +21,14 @@ applications:
       phases:
         build:
           commands:
-            # web/ has no CDK backend of its own; ts-code's Gen 2 backend
-            # is deployed independently by .github/workflows/backend-cd.yml
-            # against the "alpha" environment (an Amplify/CDK environment
-            # name, decoupled from Git branches -- there's no Git branch
-            # literally named "alpha"). Hosting's connected Git branch is
-            # "master", so --branch is hardcoded to "alpha" here rather
-            # than $AWS_BRANCH. Substituting `ampx generate outputs` for
-            # the default `ampx pipeline-deploy` is the documented way to
-            # skip Amplify Hosting's own backend deploy while still
-            # fetching config for the frontend build (there's no dedicated
-            # Gen 2 "skip backend build" flag -- that's Gen-1-only).
-            - npx ampx generate outputs --app-id $AWS_APP_ID --branch alpha --out-dir ../web
+            # web/ has no CDK backend of its own; ts-code's Gen 2 backend is
+            # deployed independently by .github/workflows/backend-cd.yml,
+            # triggered on push to this same "alpha" Git branch (which is
+            # also the CDK/ampx environment name -- see root CLAUDE.md's
+            # "Branching and environment promotion" section). Substituting
+            # `ampx generate outputs` for the default `ampx pipeline-deploy`
+            # is the documented way to skip Amplify Hosting's own backend
+            # deploy while still fetching config for the frontend build
+            # (there's no dedicated Gen 2 "skip backend build" flag --
+            # that's Gen-1-only).
+            - npx ampx generate outputs --app-id $AWS_APP_ID --branch $AWS_BRANCH --out-dir ../web


### PR DESCRIPTION
## Summary
Restructures this repo's branching model, per discussion: `alpha` (the only currently provisioned environment) becomes the active-development merge target instead of `master`. `master` is repurposed as the eventual production branch, reached via a deliberate manual promotion step — `beta` sits between them once that environment exists.

- `backend-ci.yml`, `frontend-ci.yml`: PR gate retargeted from `master` to `alpha`.
- `backend-cd.yml`: deploy trigger retargeted from push-to-`master` to push-to-`alpha`; its `ampx pipeline-deploy` target stays `alpha` (the CDK environment name — now also the Git branch name deploying it).
- `issue-branch-merged.yml`: retargeted to `alpha`; comment text updated.
- `amplify.yml`: both `ampx generate outputs` calls now use `$AWS_BRANCH` instead of a hardcoded `"alpha"` string, since Amplify Hosting connects to the `alpha` Git branch directly.
- New `promote.yml`: manual `workflow_dispatch` that fast-forwards `beta` or `master` to the appropriate source branch. Promoting to `beta` currently fails fast with a clear error, since `beta` has no infrastructure yet.
- `CLAUDE.md`: new "Branching and environment promotion" section documenting the `alpha` → `beta` → `master` model for when city/church branches are added later; every `origin/master` reference in the doc and the `issue-triage` skill updated to `origin/alpha`.

This supersedes #314 (closed), which fast-forwarded `alpha` *from* `master` — the wrong direction once `alpha` became the merge target.

## Follow-up (outside this PR, tracked separately)
- Switch the repo's actual GitHub default branch setting to `alpha` (repo Settings, not something `gh`/this PR does automatically).
- Complete the in-progress Amplify Hosting Console connection to the `alpha` branch (`web/`'s monorepo app root, service role, `AMPLIFY_APP_ORIGIN`).
- When `beta` is provisioned: update `promote.yml`'s source-branch mapping so `master` promotes from `beta` instead of directly from `alpha`.

## Test plan
- [x] `npm run build` + `npm run test:unit` pass (no `ts-code`/`amplify` logic touched — CI/CD + docs only).
- [x] All modified/new YAML validated as syntactically correct.
- [ ] CI green on this PR.
- [ ] After merge: verify `backend-ci.yml`/`frontend-ci.yml` correctly gate a test PR against `alpha`, and `backend-cd.yml` fires on push to `alpha`.
