### PR TITLE
Fix amplify.yml: install root deps before backend phase's ampx call

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -21,6 +21,11 @@ applications:
       phases:
         build:
           commands:
+            # This phase runs from the repo root, not web/ -- ampx is a root
+            # devDependency, so it needs root's own node_modules installed
+            # first (web/'s frontend-phase `npm ci` only installs web/'s
+            # separate node_modules, in appRoot).
+            - npm ci
             # web/ has no CDK backend of its own; ts-code's Gen 2 backend is
             # deployed independently by .github/workflows/backend-cd.yml,
             # triggered on push to this same "alpha" Git branch (which is


### PR DESCRIPTION
## Summary
- First real Amplify Hosting build against the `alpha` branch failed: `npx ampx generate outputs` in the backend phase errored with `npm error could not determine executable to run`.
- Root cause: the backend phase runs from the repo root, not `web/`, but nothing installs root's `node_modules` there. `web/`'s frontend-phase `npm ci` only installs `web/`'s own separate `node_modules` (it runs inside `appRoot: web`). `ampx` is a root `devDependency`, so `npx` couldn't resolve it.
- Fix: add `npm ci` as the first command in the backend phase, before the `ampx generate outputs` call.

## Test plan
- [x] Verified root `package-lock.json` is in sync (`npm ls --package-lock-only` clean) so `npm ci` won't fail on drift.
- [x] YAML syntax validated.
- [ ] Amplify Hosting build against `alpha` succeeds after this merges (manual verification in Console, since Hosting builds aren't part of this repo's CI).
